### PR TITLE
mpi small bug fix

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LatticeDiracOperators"
 uuid = "019239df-b0e3-486e-8e4c-d1c29ee5d6b9"
 authors = ["Akio Tomiya, Yuki Nagai <cometscome@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 AlgRemez_jll = "acb6dc63-88f0-54c7-a126-ccdc963b8b3f"

--- a/fordebug/staggered/staggered_mpitest.jl
+++ b/fordebug/staggered/staggered_mpitest.jl
@@ -1,0 +1,312 @@
+using Gaugefields
+using MPI
+using LinearAlgebra
+using Random
+using LatticeDiracOperators
+import Gaugefields.AbstractGaugefields_module:getvalue,setvalue!
+
+
+#=
+if length(ARGS)<7
+    error("USAGE:\njulia exe.jl nPEx nPEy nPEz nPEt mpi-true/false Ntrj nMDsteps")
+end
+=#
+if length(ARGS)<6
+    error("USAGE:\njulia exe.jl nPEx nPEy nPEz nPEt mpi-true/false Ntrj")
+end
+
+const pes = Tuple(parse.(Int64,ARGS[1:4]))
+const mpi = parse(Bool,ARGS[5])
+const numtrj_in = parse(Int64, ARGS[6])
+const MDsteps_in = 0# parse(Int64, ARGS[7])
+
+const βin = 6.0
+const NXin = 8
+const NYin = 8
+const NZin = 8
+const NTin = 8
+
+println(
+"""
+Parameters
+const pes = $pes
+const mpi = $mpi
+const numtrj_in = $numtrj_in
+const MDsteps_in = $MDsteps_in
+
+const βin = $βin
+const NXin = $NXin
+const NYin = $NYin
+const NZin = $NZin
+const NTin = $NTin
+"""
+)
+
+
+function MDtest!(snet,U,Dim,mpi=false)
+    p = initialize_TA_Gaugefields(U)
+    Uold = similar(U)
+    substitute_U!(Uold,U)
+    MDsteps = MDsteps_in
+    temp1 = similar(U[1])
+    temp2 = similar(U[1])
+    comb = 6
+    factor = 1/(comb*U[1].NV*U[1].NC)
+    numaccepted = 0
+
+    plaq_t = calculate_Plaquette(U,temp1,temp2)*factor
+
+    poly = calculate_Polyakov_loop(U,temp1,temp2) 
+    if get_myrank(U) == 0
+        println("0 $plaq_t # plaquette")
+        println("0 $(real(poly)) $(imag(poly)) # polyakovloop")
+    end
+
+
+    numtrj = numtrj_in
+    for itrj = 1:numtrj
+        accepted, runtime = @timed MDstep!(snet,U,p,MDsteps,Dim,Uold)
+        numaccepted += ifelse(accepted,1,0)
+
+        plaq_t = calculate_Plaquette(U,temp1,temp2)*factor
+        poly = calculate_Polyakov_loop(U,temp1,temp2) 
+        
+        if get_myrank(U) == 0
+            #println("$itrj plaq_t = $plaq_t")
+            println("$itrj $(numaccepted/itrj) #acceptance")
+            println("$itrj $runtime # runtime")
+            #println("polyakov loop = $(real(poly)) $(imag(poly))")
+            println("$itrj $plaq_t # plaquette")
+            println("$itrj $(real(poly)) $(imag(poly)) # polyakovloop")
+        end
+    end
+end
+
+function calc_action(snet,U,p)
+    NC = U[1].NC
+    Sg = -evaluate_GaugeAction(snet,U)/NC
+    Sp = p*p/2
+    S = Sp + Sg
+    return real(S)
+end
+
+function MDstep!(snet,U,p,MDsteps,Dim,Uold)
+    Δτ = 1/MDsteps
+    gauss_distribution!(p)
+    Sold = calc_action(snet,U,p)
+    substitute_U!(Uold,U)
+
+    for itrj=1:MDsteps
+        U_update!(U,p,0.5,Δτ,Dim,snet)
+        #println(getvalue(U[1],1,1,1,1,1,1))
+
+        P_update!(U,p,1.0,Δτ,Dim,snet)
+        #if get_myrank(U) == 0
+        #    println(getvalue(U[1],1,1,1,1,1,1))
+        #    println("p = ",p[1][1,1,1,1,1])
+        #    if isnan(p[1][1,1,1,1,1])
+        #        error("p")
+        #    end
+        #end
+
+
+        U_update!(U,p,0.5,Δτ,Dim,snet)
+        #error("dd")
+    end
+    #error("end")
+    
+    Snew = calc_action(snet,U,p)
+    if get_myrank(U) == 0
+        println("Sold = $Sold, Snew = $Snew")
+        println("Snew - Sold = $(Snew-Sold)")
+    end
+    ratio = min(1,exp(Snew-Sold))
+    r = rand()
+    if mpi
+        r = MPI.bcast(r, 0, MPI.COMM_WORLD)
+    end
+    #println(r,"\t",ratio)
+
+    if r > ratio
+        substitute_U!(U,Uold)
+        return false
+    else
+        return true
+    end
+end
+
+function U_update!(U,p,ϵ,Δτ,Dim,snet)
+    temps = get_temporary_gaugefields(snet)
+    temp1 = temps[1]
+    temp2 = temps[2]
+    expU = temps[3]
+    W = temps[4]
+
+    for μ=1:Dim
+        exptU!(expU,ϵ*Δτ,p[μ],[temp1,temp2])
+        mul!(W,expU,U[μ])
+        substitute_U!(U[μ],W)
+        
+    end
+end
+
+function P_update!(U,p,ϵ,Δτ,Dim,snet) # p -> p +factor*U*dSdUμ
+    NC = U[1].NC
+    temps = get_temporary_gaugefields(snet)
+    dSdUμ = temps[end]
+    factor =  -ϵ*Δτ/(NC)
+
+    for μ=1:Dim
+        calc_dSdUμ!(dSdUμ,snet,μ,U)
+        #println("dSdU = ",getvalue(dSdUμ,1,1,1,1,1,1))
+        mul!(temps[1],U[μ],dSdUμ) # U*dSdUμ
+        Traceless_antihermitian_add!(p[μ],factor,temps[1])
+    end
+end
+
+
+
+function test1()
+    NX = NXin
+    NY = NYin
+    NZ = NZin
+    NT = NTin
+    Nwing = 0
+    Dim = 4
+    NC = 3
+
+
+    if mpi
+        PEs = pes#(1,1,1,2)
+        U = Initialize_Gaugefields(NC,Nwing,NX,NY,NZ,NT,condition = "cold",mpi=true,PEs = PEs,mpiinit = false)
+        
+    else
+        U = Initialize_Gaugefields(NC,Nwing,NX,NY,NZ,NT,condition = "cold")
+
+    end
+
+    Random.seed!(123+get_myrank(U[1]))    
+
+
+
+    snet = GaugeAction(U)
+    plaqloop = make_loops_fromname("plaquette")
+    append!(plaqloop,plaqloop')
+    β = βin/2
+    push!(snet,β,plaqloop)
+    
+    #show(snet)
+
+    nowing = true
+    Random.seed!(123)
+    x = Initialize_pseudofermion_fields(U[1],"staggered",nowing = nowing)
+
+    params = Dict()
+    params["Dirac_operator"] = "staggered"
+    params["mass"] = 0.5
+    params["eps_CG"] = 1.0e-19
+    params["verbose_level"] = 2
+
+    D = Dirac_operator(U,x,params)
+
+    
+    setindex_global!(x,10.0,1,1,1,1,1,1)
+    setindex_global!(x,im,1,2,1,1,1,1)
+    setindex_global!(x,2im,1,3,1,1,1,1)
+    setindex_global!(x,3im,1,4,1,1,1,1)
+    setindex_global!(x,10.0,1,1,2,1,1,1)
+    setindex_global!(x,im,1,2,1,1,4,1)
+    setindex_global!(x,2im,1,3,1,4,1,1)
+    setindex_global!(x,3im,1,4,1,1,1,1)
+    #=
+
+    if mpi
+        if x.myrank == 0
+            setvalue!(x,10.0,1,1,1,1,1,1)
+            setvalue!(x,im,1,2,1,1,1,1)
+            setvalue!(x,2im,1,3,1,1,1,1)
+            setvalue!(x,3im,1,4,1,1,1,1)
+            setvalue!(x,10.0,1,1,2,1,1,1)
+            setvalue!(x,im,1,2,1,1,4,1)
+            setvalue!(x,2im,1,3,1,4,1,1)
+            setvalue!(x,3im,1,4,1,1,1,1)
+        end
+        
+    else
+        setvalue_fermion!(x,10.0,1,1,1,1,1,1)
+        setvalue_fermion!(x,im,1,2,1,1,1,1)
+        setvalue_fermion!(x,2im,1,3,1,1,1,1)
+        setvalue_fermion!(x,3im,1,4,1,1,1,1)
+        setvalue_fermion!(x,10.0,1,1,2,1,1,1)
+        setvalue_fermion!(x,im,1,2,1,1,4,1)
+        setvalue_fermion!(x,2im,1,3,1,4,1,1)
+        setvalue_fermion!(x,3im,1,4,1,1,1,1)
+        
+    end
+    =#
+    set_wing_fermion!(x)
+
+    
+
+    if mpi
+        if x.myrank == 0
+            println(getvalue(x,1,1,1,1,1,1))
+            println(getvalue(x,1,1,2,1,1,1))
+        end
+    else
+        println(x[1,1,1,1,1,1])
+        println(x[1,2,1,1,1,1])
+    end
+    #Random.seed!(123)
+    #gauss_distribution_fermion!(x)
+    
+
+    b = similar(x)
+    y = similar(x)
+    @time solve_DinvX!(b,D,x)
+    @time mul!(b,D,x)
+    @time mul!(b,D,x)
+
+    if mpi 
+        if x.myrank == 0
+            println(getvalue(b,1,1,1,1,1,1))
+            println(getvalue(b,1,1,2,1,1,1))
+        end
+    else
+        println(b[1,1,1,1,1,1])
+        println(b[1,2,1,1,1,1])
+    end
+
+    #return
+    println_verbose_level1(U[1],"Benchmark!!")
+    @time solve_DinvX!(y,D,b)
+
+    println_verbose_level1(U[1],"We check whether y = D^-1 (Dx) = x")
+    if mpi 
+        if x.myrank == 0
+            println(getvalue(y,1,1,1,1,1,1))
+            println(getvalue(y,1,2,1,1,1,1))
+        end
+    else
+        println(y[1,1,1,1,1,1])
+        println(y[1,2,1,1,1,1])
+    end
+
+    println_verbose_level1(U[1],"several times!!!")
+    for itrj=1:numtrj_in 
+        println_verbose_level1(U[1],"itrj = $itrj")
+        gauss_distribution_fermion!(x)
+        @time solve_DinvX!(y,D,x)
+    end
+
+
+
+    #MDtest!(snet,U,Dim,mpi)
+
+end
+
+
+test1()
+if mpi
+   MPI.Finalize()
+end

--- a/run/mpiwilsontest_imp.jl
+++ b/run/mpiwilsontest_imp.jl
@@ -1,0 +1,304 @@
+using InteractiveUtils
+#versioninfo()
+using Gaugefields
+using MPI
+using LinearAlgebra
+using Random
+using LatticeDiracOperators
+
+import Gaugefields.AbstractGaugefields_module:getvalue,setvalue!
+
+
+#=
+if length(ARGS)<7
+    error("USAGE:\njulia exe.jl nPEx nPEy nPEz nPEt mpi-true/false Ntrj nMDsteps")
+end
+=#
+if length(ARGS)<5
+    error("USAGE:\njulia exe.jl nPEx nPEy nPEz nPEt mpi-true/false")
+end
+
+println("Test for 1/D for Wilson MPI")
+
+versioninfo()
+
+const pes = Tuple(parse.(Int64,ARGS[1:4]))
+const mpi = parse(Bool,ARGS[5])
+const numtrj_in = 10 # parse(Int64, ARGS[6])
+const MDsteps_in = 0 # parse(Int64, ARGS[7])
+
+const βin = 6.0
+const NXin = 16
+const NYin = 16
+const NZin = 16
+const NTin = 32
+const κin = 0.141139
+
+header = """
+Parameters
+const pes = $pes
+const mpi = $mpi
+const numtrj_in = $numtrj_in
+const MDsteps_in = $MDsteps_in
+
+const βin = $βin
+const NXin = $NXin
+const NYin = $NYin
+const NZin = $NZin
+const NTin = $NTin
+const κin = $κin
+"""
+
+
+function MDtest!(snet,U,Dim,mpi=false)
+    p = initialize_TA_Gaugefields(U)
+    Uold = similar(U)
+    substitute_U!(Uold,U)
+    MDsteps = MDsteps_in
+    temp1 = similar(U[1])
+    temp2 = similar(U[1])
+    comb = 6
+    factor = 1/(comb*U[1].NV*U[1].NC)
+    numaccepted = 0
+
+    plaq_t = calculate_Plaquette(U,temp1,temp2)*factor
+
+    poly = calculate_Polyakov_loop(U,temp1,temp2) 
+    if get_myrank(U) == 0
+        println("0 $plaq_t # plaquette")
+        println("0 $(real(poly)) $(imag(poly)) # polyakovloop")
+    end
+
+
+    numtrj = numtrj_in
+    for itrj = 1:numtrj
+        accepted, runtime = @timed MDstep!(snet,U,p,MDsteps,Dim,Uold)
+        numaccepted += ifelse(accepted,1,0)
+
+        plaq_t = calculate_Plaquette(U,temp1,temp2)*factor
+        poly = calculate_Polyakov_loop(U,temp1,temp2) 
+        
+        if get_myrank(U) == 0
+            #println("$itrj plaq_t = $plaq_t")
+            println("$itrj $(numaccepted/itrj) #acceptance")
+            println("$itrj $runtime # runtime")
+            #println("polyakov loop = $(real(poly)) $(imag(poly))")
+            println("$itrj $plaq_t # plaquette")
+            println("$itrj $(real(poly)) $(imag(poly)) # polyakovloop")
+        end
+    end
+end
+
+function calc_action(snet,U,p)
+    NC = U[1].NC
+    Sg = -evaluate_GaugeAction(snet,U)/NC
+    Sp = p*p/2
+    S = Sp + Sg
+    return real(S)
+end
+
+function MDstep!(snet,U,p,MDsteps,Dim,Uold)
+    Δτ = 1/MDsteps
+    gauss_distribution!(p)
+    Sold = calc_action(snet,U,p)
+    substitute_U!(Uold,U)
+
+    for itrj=1:MDsteps
+        U_update!(U,p,0.5,Δτ,Dim,snet)
+        #println(getvalue(U[1],1,1,1,1,1,1))
+
+        P_update!(U,p,1.0,Δτ,Dim,snet)
+        #if get_myrank(U) == 0
+        #    println(getvalue(U[1],1,1,1,1,1,1))
+        #    println("p = ",p[1][1,1,1,1,1])
+        #    if isnan(p[1][1,1,1,1,1])
+        #        error("p")
+        #    end
+        #end
+
+
+        U_update!(U,p,0.5,Δτ,Dim,snet)
+        #error("dd")
+    end
+    #error("end")
+    
+    Snew = calc_action(snet,U,p)
+    if get_myrank(U) == 0
+        println("Sold = $Sold, Snew = $Snew")
+        println("Snew - Sold = $(Snew-Sold)")
+    end
+    ratio = min(1,exp(Snew-Sold))
+    r = rand()
+    if mpi
+        r = MPI.bcast(r, 0, MPI.COMM_WORLD)
+    end
+    #println(r,"\t",ratio)
+
+    if r > ratio
+        substitute_U!(U,Uold)
+        return false
+    else
+        return true
+    end
+end
+
+function U_update!(U,p,ϵ,Δτ,Dim,snet)
+    temps = get_temporary_gaugefields(snet)
+    temp1 = temps[1]
+    temp2 = temps[2]
+    expU = temps[3]
+    W = temps[4]
+
+    for μ=1:Dim
+        exptU!(expU,ϵ*Δτ,p[μ],[temp1,temp2])
+        mul!(W,expU,U[μ])
+        substitute_U!(U[μ],W)
+        
+    end
+end
+
+function P_update!(U,p,ϵ,Δτ,Dim,snet) # p -> p +factor*U*dSdUμ
+    NC = U[1].NC
+    temps = get_temporary_gaugefields(snet)
+    dSdUμ = temps[end]
+    factor =  -ϵ*Δτ/(NC)
+
+    for μ=1:Dim
+        calc_dSdUμ!(dSdUμ,snet,μ,U)
+        #println("dSdU = ",getvalue(dSdUμ,1,1,1,1,1,1))
+        mul!(temps[1],U[μ],dSdUμ) # U*dSdUμ
+        Traceless_antihermitian_add!(p[μ],factor,temps[1])
+    end
+end
+
+
+
+function test1()
+    NX = NXin
+    NY = NYin
+    NZ = NZin
+    NT = NTin
+    Nwing = 0
+    Dim = 4
+    NC = 3
+
+
+    if mpi
+        PEs = pes#(1,1,1,2)
+        U = Initialize_Gaugefields(NC,Nwing,NX,NY,NZ,NT,condition = "cold",mpi=true,PEs = PEs,mpiinit = false)
+        
+    else
+        U = Initialize_Gaugefields(NC,Nwing,NX,NY,NZ,NT,condition = "cold")
+
+    end
+
+    Random.seed!(123+get_myrank(U[1]))    
+
+    if get_myrank(U) == 0
+        println(header) # print header
+    end
+
+    snet = GaugeAction(U)
+    plaqloop = make_loops_fromname("plaquette")
+    append!(plaqloop,plaqloop')
+    β = βin/2
+    push!(snet,β,plaqloop)
+    
+    #show(snet)
+
+    nowing = true
+    Random.seed!(123)
+    x = Initialize_pseudofermion_fields(U[1],"Wilson",nowing = nowing)
+
+    params = Dict()
+    params["Dirac_operator"] = "Wilson"
+    params["κ"] = κin
+    params["faster version"] = true
+    params["eps_CG"] = 1.0e-16
+    params["verbose_level"] = 3 # to show CG counts
+
+    D = Dirac_operator(U,x,params)
+
+    if mpi
+        if x.myrank == 0
+            setvalue!(x,10.0,1,1,1,1,1,1)
+            setvalue!(x,im,1,2,1,1,1,1)
+            setvalue!(x,2im,1,3,1,1,1,1)
+            setvalue!(x,3im,1,4,1,1,1,1)
+            setvalue!(x,10.0,1,1,2,1,1,1)
+            setvalue!(x,im,1,2,1,1,4,1)
+            setvalue!(x,2im,1,3,1,4,1,1)
+            setvalue!(x,3im,1,4,1,1,1,1)
+        end
+        
+    else
+        setvalue_fermion!(x,10.0,1,1,1,1,1,1)
+        setvalue_fermion!(x,im,1,2,1,1,1,1)
+        setvalue_fermion!(x,2im,1,3,1,1,1,1)
+        setvalue_fermion!(x,3im,1,4,1,1,1,1)
+        setvalue_fermion!(x,10.0,1,1,2,1,1,1)
+        setvalue_fermion!(x,im,1,2,1,1,4,1)
+        setvalue_fermion!(x,2im,1,3,1,4,1,1)
+        setvalue_fermion!(x,3im,1,4,1,1,1,1)
+        
+    end
+    set_wing_fermion!(x)
+
+    
+
+    if mpi
+        if x.myrank == 0
+            println(getvalue(x,1,1,1,1,1,1))
+            println(getvalue(x,1,2,1,1,1,1))
+        end
+    else
+        println(x[1,1,1,1,1,1])
+        println(x[1,2,1,1,1,1])
+    end
+    #Random.seed!(123)
+    #gauss_distribution_fermion!(x)
+    
+
+    b = similar(x)
+    y = similar(x)
+    @time solve_DinvX!(b,D,x)
+    @time mul!(b,D,x)
+    @time mul!(b,D,x)
+
+    #return
+    println_verbose_level1(U[1],"Benchmark!!")
+    @time solve_DinvX!(y,D,b)
+
+    println_verbose_level1(U[1],"We check whether y = D^-1 (Dx) = x")
+    if mpi 
+        if x.myrank == 0
+            println(getvalue(y,1,1,1,1,1,1))
+            println(getvalue(y,1,2,1,1,1,1))
+        end
+    else
+        println(y[1,1,1,1,1,1])
+        println(y[1,2,1,1,1,1])
+    end
+
+    println_verbose_level1(U[1],"several times!!!")
+    elptime = 0.0
+    tmp = 0.0
+    for itrj=1:numtrj_in 
+        println_verbose_level1(U[1],"itrj = $itrj")
+        gauss_distribution_fermion!(x)
+        tmp = @elapsed solve_DinvX!(y,D,x)
+        elptime+=tmp
+    end
+    elptime/=numtrj_in
+    println_verbose_level1(U[1],"$eltime #Dtime")
+
+
+    #MDtest!(snet,U,Dim,mpi)
+
+end
+
+
+test1()
+if mpi
+    MPI.Finalize()
+end

--- a/src/AbstractFermions.jl
+++ b/src/AbstractFermions.jl
@@ -5,6 +5,14 @@ using Requires
 abstract type Abstractfermion# <: AbstractVector{ComplexF64}
 end
 
+function get_myrank(x::T) where {T<:Abstractfermion}
+    return 0
+end
+
+function get_nprocs(x::T) where {T<:Abstractfermion}
+    return 0
+end
+
 abstract type AbstractFermionfields{NC,Dim} <: Abstractfermion end
 
 

--- a/src/AbstractFermions_4D.jl
+++ b/src/AbstractFermions_4D.jl
@@ -4,6 +4,8 @@ abstract type AbstractFermionfields_4D{NC} <: AbstractFermionfields{NC,4} end
 
 
 
+
+
 function Base.setindex!(x::T, v, i1, i2, i3, i4, i5, i6) where {T<:AbstractFermionfields_4D}
     @inbounds x.f[i1, i2+x.NDW, i3+x.NDW, i4+x.NDW, i5+x.NDW, i6] = v
 end

--- a/src/Diracoperators.jl
+++ b/src/Diracoperators.jl
@@ -172,6 +172,7 @@ function solve_DinvX!(
     A::T2,
     x::T3,
 ) where {T1<:AbstractFermionfields,T2<:Dirac_operator,T3<:AbstractFermionfields}
+    #println("print $(A.verbose_print)")
     if A.method_CG == "bicg"
         bicg(y, A, x; eps = A.eps_CG, maxsteps = A.MaxCGstep, verbose = A.verbose_print)#set_verbose(A.verbose_level)) 
         set_wing_fermion!(y, A.boundarycondition)

--- a/src/DomainwallFermion/DomainwallFermion.jl
+++ b/src/DomainwallFermion/DomainwallFermion.jl
@@ -86,7 +86,8 @@ function D5DW_Domainwall_operator(
     MaxCGstep = check_parameters(parameters, "MaxCGstep", default_MaxCGstep)
 
     verbose_level = check_parameters(parameters, "verbose_level", 2)
-    verbose_print = Verbose_print(verbose_level)
+    #verbose_print = Verbose_print(verbose_level)
+    verbose_print = Verbose_print(verbose_level,myid=get_myrank(x))
 
     method_CG = check_parameters(parameters, "method_CG", "bicg")
     #println("xtype ",xtype)

--- a/src/StaggeredFermion/StaggeredFermion.jl
+++ b/src/StaggeredFermion/StaggeredFermion.jl
@@ -53,7 +53,8 @@ function Staggered_Dirac_operator(
         _temporary_fermion_forCG[i] = similar(x)
     end
 
-    verbose_print = Verbose_print(verbose_level)
+    #verbose_print = Verbose_print(verbose_level)
+    verbose_print = Verbose_print(verbose_level,myid=get_myrank(x))
 
     return Staggered_Dirac_operator{Dim,eltype(U),xtype}(
         U,

--- a/src/WilsonFermion/WilsonFermion.jl
+++ b/src/WilsonFermion/WilsonFermion.jl
@@ -150,7 +150,7 @@ function Wilson_Dirac_operator(
     MaxCGstep = check_parameters(parameters, "MaxCGstep", default_MaxCGstep)
 
     verbose_level = check_parameters(parameters, "verbose_level", 2)
-    verbose_print = Verbose_print(verbose_level)
+    verbose_print = Verbose_print(verbose_level,myid=get_myrank(x))
 
     method_CG = check_parameters(parameters, "method_CG", "bicg")
 

--- a/src/WilsonFermion/WilsonFermion_faster.jl
+++ b/src/WilsonFermion/WilsonFermion_faster.jl
@@ -147,7 +147,7 @@ function Wilson_Dirac_operator_faster(
 
     verbose_level = check_parameters(parameters, "verbose_level", 2)
     #verbose_print = Verbose_print(verbose_level)
-    #println("myid ",get_myrank(x))
+    
     verbose_print = Verbose_print(verbose_level,myid=get_myrank(x))
 
     method_CG = check_parameters(parameters, "method_CG", "bicg")

--- a/src/WilsonFermion/WilsonFermion_faster.jl
+++ b/src/WilsonFermion/WilsonFermion_faster.jl
@@ -146,7 +146,9 @@ function Wilson_Dirac_operator_faster(
     MaxCGstep = check_parameters(parameters, "MaxCGstep", default_MaxCGstep)
 
     verbose_level = check_parameters(parameters, "verbose_level", 2)
-    verbose_print = Verbose_print(verbose_level)
+    #verbose_print = Verbose_print(verbose_level)
+    #println("myid ",get_myrank(x))
+    verbose_print = Verbose_print(verbose_level,myid=get_myrank(x))
 
     method_CG = check_parameters(parameters, "method_CG", "bicg")
 

--- a/test/hmc.jl
+++ b/test/hmc.jl
@@ -5,7 +5,7 @@ function MDtest!(gauge_action,U,Dim,fermi_action,η,ξ)
     p = initialize_TA_Gaugefields(U) #This is a traceless-antihermitian gauge fields. This has NC^2-1 real coefficients. 
     Uold = similar(U)
     substitute_U!(Uold,U)
-    MDsteps = 20
+    MDsteps = 30
     temp1 = similar(U[1])
     temp2 = similar(U[1])
     comb = 6


### PR DESCRIPTION
When we use the MPI parallel computations, the verbose_print function should work only in rank 0. In the definition of the Dirac operators, we have to use the rank to create the Verbose_print variable. So I fixed it.