### PR TITLE
[codex] Fix 2D Wilson gamma5 indexing

### DIFF
--- a/src/WilsonFermion/WilsonFermion_2D_wing.jl
+++ b/src/WilsonFermion/WilsonFermion_2D_wing.jl
@@ -715,7 +715,7 @@ function mul_γ5x!(y::WilsonFermion_2D_wing{NC}, x::WilsonFermion_2D_wing{NC}) w
             for i2 = 1:n2
                 #ix = i2+NDW
                 @simd for ic = 1:NC
-                    y.f[i1, i2, i5, i6] = x.f[i1, i2, i5, i6] * ifelse(i6 == 2, -1, 1)
+                    y.f[ic, i2, i5, i6] = x.f[ic, i2, i5, i6] * ifelse(i6 == 2, -1, 1)
                 end
             end
             #end
@@ -739,7 +739,7 @@ function apply_γ5!(x::WilsonFermion_2D_wing{NC}) where {NC}
             for i2 = 1:n2
                 #ix = i2+NDW
                 @simd for ic = 1:NC
-                    x.f[i1, i2, i5, i6] = x.f[i1, i2, i5, i6] * ifelse(i6 == 2, -1, 1)
+                    x.f[ic, i2, i5, i6] = x.f[ic, i2, i5, i6] * ifelse(i6 == 2, -1, 1)
                 end
             end
             #end

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -1,6 +1,8 @@
 
+using Gaugefields
 using LinearAlgebra
 using LatticeDiracOperators
+using Test
 
 function test_staggered()
     NX = 4
@@ -133,5 +135,34 @@ function test_wilson()
 
 
 end
+
+function test_wilson_2d_gamma5()
+    NX = 2
+    NT = 2
+    Nwing = 0
+    NC = 2
+
+    U = Initialize_Gaugefields(NC, Nwing, NX, NT, condition="cold")
+    x = Initialize_pseudofermion_fields(U[1], "Wilson")
+    y = similar(x)
+
+    for I in CartesianIndices(x.f)
+        x.f[I] = ComplexF64(1000 * I[4] + 100 * I[3] + 10 * I[2] + I[1])
+    end
+
+    LatticeDiracOperators.Dirac_operators.mul_γ5x!(y, x)
+    for I in CartesianIndices(x.f)
+        sign = ifelse(I[4] == 2, -1, 1)
+        @test y.f[I] == sign * x.f[I]
+    end
+
+    z = deepcopy(x)
+    LatticeDiracOperators.Dirac_operators.apply_γ5!(z)
+    for I in CartesianIndices(x.f)
+        sign = ifelse(I[4] == 2, -1, 1)
+        @test z.f[I] == sign * x.f[I]
+    end
+end
 #test_staggered()
+test_wilson_2d_gamma5()
 test_wilson()


### PR DESCRIPTION
## Summary

Fixes the 2D Wilson fermion gamma5 helpers to use the active color-loop variable when reading and writing field components.

## Root cause

`mul_γ5x!` and `apply_γ5!` loop over `ic = 1:NC`, but the array access used `i1`, which is undefined in those methods. Calling the 2D gamma5 path could therefore throw `UndefVarError` instead of applying `sigma_3` to the spin component.

## Changes

- Replace the undefined `i1` index with `ic` in the 2D Wilson `mul_γ5x!` and `apply_γ5!` implementations.
- Add a focused 2D Wilson gamma5 test covering all field-array entries.
- Make `test/basic.jl` import `Gaugefields` and `Test` explicitly.

## Validation

Ran:

```bash
/Users/akio/.juliaup/bin/julia --project=/private/tmp/ldo_gamma5_test_env -e 'include("/Users/akio/repository/sym_twisted/LatticeDiracOperators.jl_pr/test/basic.jl")'
```

The repository Manifest has local absolute paths for `Gaugefields` and `LatticeMatrices` that do not exist on this machine, so I used a temporary Julia project with local `develop` paths for those dependencies.