### PR TITLE
[codex] Fix Wilson gamma5 and add clover checkpoints

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,19 +1,52 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Accessors]]
+deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
+uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
+version = "0.1.45"
+
+    [Accessors.extensions]
+    AxisKeysExt = "AxisKeys"
+    IntervalSetsExt = "IntervalSets"
+    LinearAlgebraExt = "LinearAlgebra"
+    StaticArraysExt = "StaticArrays"
+    StructArraysExt = "StructArrays"
+    TestExt = "Test"
+    UnitfulExt = "Unitful"
+
+    [Accessors.weakdeps]
+    AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+
 [[AlgRemez_jll]]
 deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "MPFR_jll", "Pkg"]
 git-tree-sha1 = "491f3c8c89a7aa6f89c76642032e1eebf8f1cd8a"
 uuid = "acb6dc63-88f0-54c7-a126-ccdc963b8b3f"
 version = "0.1.1+0"
 
+[[AliasTables]]
+deps = ["PtrArrays", "Random"]
+git-tree-sha1 = "9876e1e164b144ca45e9e3198d0b689cadfed9ff"
+uuid = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
+version = "1.1.3"
+
 [[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
 
 [[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[CLIME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -21,254 +54,375 @@ git-tree-sha1 = "317144c2bc37c62db8035746298f96050ef4c3aa"
 uuid = "3c6ae550-c37b-5556-a07e-d40b4910cf1c"
 version = "1.3.2+0"
 
-[[ChainRulesCore]]
-deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "f9982ef575e19b0e5c7a98c6e75ee496c0f73a93"
-uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.12.0"
-
-[[ChangesOfVariables]]
-deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
-git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
-uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.2"
-
-[[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
-uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.41.0"
+[[CommonSolve]]
+git-tree-sha1 = "99ee296f88c12485402e37c2fd025f95ae097637"
+uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
+version = "0.2.9"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[CompositionsBase]]
+git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.2"
+weakdeps = ["InverseFunctions"]
+
+    [CompositionsBase.extensions]
+    CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[ConstructionBase]]
+git-tree-sha1 = "b4b092499347b18a015186eae3042f72267106cb"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.6.0"
+
+    [ConstructionBase.extensions]
+    ConstructionBaseIntervalSetsExt = "IntervalSets"
+    ConstructionBaseLinearAlgebraExt = "LinearAlgebra"
+    ConstructionBaseStaticArraysExt = "StaticArrays"
+
+    [ConstructionBase.weakdeps]
+    IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
+    LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [[DataAPI]]
-git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
+git-tree-sha1 = "abe83f3a2f1b857aac70ef8b269080af17764bbe"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.9.0"
+version = "1.16.0"
 
 [[DataStructures]]
-deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
+deps = ["OrderedCollections"]
+git-tree-sha1 = "6fb53a69613a0b2b68a0d12671717d307ab8b24e"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.11"
+version = "0.19.5"
 
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
-
-[[DelimitedFiles]]
-deps = ["Mmap"]
-uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
-
-[[DensityInterface]]
-deps = ["InverseFunctions", "Test"]
-git-tree-sha1 = "80c3e8639e3353e5d2912fb3a1916b8455e2494b"
-uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
-version = "0.4.0"
-
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+version = "1.11.0"
 
 [[Distributions]]
-deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
-git-tree-sha1 = "38012bf3553d01255e83928eec9c998e19adfddf"
+deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
+git-tree-sha1 = "cd3c5ac74cd3923c8945c6a81518c46abd0e73a3"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.48"
+version = "0.25.129"
+
+    [Distributions.extensions]
+    DistributionsChainRulesCoreExt = "ChainRulesCore"
+    DistributionsDensityInterfaceExt = "DensityInterface"
+    DistributionsSparseConnectivityTracerExt = "SparseConnectivityTracer"
+    DistributionsTestExt = "Test"
+
+    [Distributions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    DensityInterface = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+    SparseConnectivityTracer = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[DocStringExtensions]]
-deps = ["LibGit2"]
-git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+git-tree-sha1 = "7442a5dfe1ebb773c29cc2962a8980f47221d76c"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.6"
+version = "0.9.5"
 
 [[Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
 
 [[EzXML]]
 deps = ["Printf", "XML2_jll"]
-git-tree-sha1 = "0fa3b52a04a4e210aeb1626def9c90df3ae65268"
+git-tree-sha1 = "7ea1aa5869e2626ccae84480e4f37185bc6f41d3"
 uuid = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
-version = "1.1.0"
+version = "1.2.3"
 
 [[FileIO]]
 deps = ["Pkg", "Requires", "UUIDs"]
-git-tree-sha1 = "80ced645013a5dbdc52cf70329399c35ce007fae"
+git-tree-sha1 = "8e9c059d6857607253e837730dbf780b6b151acd"
 uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
-version = "1.13.0"
+version = "1.19.0"
+
+    [FileIO.extensions]
+    HTTPExt = "HTTP"
+
+    [FileIO.weakdeps]
+    HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
 
 [[FillArrays]]
-deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
-git-tree-sha1 = "deed294cde3de20ae0b2e0355a6c4e1c6a5ceffc"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "2f979084d1e13948a3352cf64a25df6bd3b4dca3"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "0.12.8"
+version = "1.16.0"
+
+    [FillArrays.extensions]
+    FillArraysPDMatsExt = "PDMats"
+    FillArraysSparseArraysExt = "SparseArrays"
+    FillArraysStaticArraysExt = "StaticArrays"
+    FillArraysStatisticsExt = "Statistics"
+
+    [FillArrays.weakdeps]
+    PDMats = "90014a1f-27ba-587c-ab20-58faa44d9150"
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[GMP_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
+version = "6.3.0+2"
+
+[[Gamma]]
+git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
+uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
+version = "1.1.0"
 
 [[Gaugefields]]
 deps = ["CLIME_jll", "Distributions", "EzXML", "InteractiveUtils", "JLD2", "LinearAlgebra", "Random", "Requires", "StableRNGs", "Wilsonloop"]
-git-tree-sha1 = "14df75dd03c99e9e36ff69c4f3b2ae47f8b8816f"
-repo-rev = "master"
-repo-url = "https://github.com/akio-tomiya/Gaugefields.jl.git"
+path = "/Users/akio/repository/Gaugefields.jl"
 uuid = "a461e10c-0d91-493e-bc41-027b226eee91"
 version = "0.1.2"
+
+[[HypergeometricFunctions]]
+deps = ["Gamma", "LinearAlgebra"]
+git-tree-sha1 = "18d7deab5fb0440dc6a7b6993c5c27b25420de10"
+uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
+version = "0.3.29"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[InverseFunctions]]
-deps = ["Test"]
-git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
+git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.2"
+version = "0.1.17"
+
+    [InverseFunctions.extensions]
+    InverseFunctionsDatesExt = "Dates"
+    InverseFunctionsTestExt = "Test"
+
+    [InverseFunctions.weakdeps]
+    Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[IrrationalConstants]]
-git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+git-tree-sha1 = "b2d91fe939cae05960e760110b328288867b5758"
 uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
-version = "0.1.1"
+version = "0.2.6"
 
 [[JLD2]]
-deps = ["DataStructures", "FileIO", "MacroTools", "Mmap", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "b528d68220e2aba1d2d0c0461b6f7eda8c5c1e33"
+deps = ["FileIO", "MacroTools", "Mmap", "OrderedCollections", "PrecompileTools", "Reexport", "Requires", "TranscodingStreams", "UUIDs", "Unicode"]
+git-tree-sha1 = "67d4690d32c22e28818a434b293a374cc78473d3"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.20"
+version = "0.4.51"
 
 [[JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.3.0"
+version = "1.8.0"
+
+[[JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
 
 [[LaTeXStrings]]
-git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
+git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.3.0"
+version = "1.4.0"
+
+[[LatticeDiracOperators]]
+deps = ["AlgRemez_jll", "Gaugefields", "InteractiveUtils", "LinearAlgebra", "Random", "Requires", "SparseArrays", "Wilsonloop"]
+path = "."
+uuid = "019239df-b0e3-486e-8e4c-d1c29ee5d6b9"
+version = "0.0.1"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
 
 [[LibCURL_jll]]
-deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
 
 [[LibGit2]]
-deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
 
 [[LibSSH2_jll]]
-deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[Libiconv_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
-version = "1.16.1+1"
+version = "1.18.0+0"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
 
 [[LogExpFunctions]]
-deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
+deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.6"
+version = "1.0.1"
+
+    [LogExpFunctions.extensions]
+    LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
+    LogExpFunctionsChangesOfVariablesExt = "ChangesOfVariables"
+    LogExpFunctionsInverseFunctionsExt = "InverseFunctions"
+
+    [LogExpFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ChangesOfVariables = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[MPFR_jll]]
 deps = ["Artifacts", "GMP_jll", "Libdl"]
 uuid = "3a97d323-0669-5f0c-9066-3539efd106a3"
+version = "4.2.2+0"
 
 [[MacroTools]]
-deps = ["Markdown", "Random"]
-git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
+git-tree-sha1 = "1e0228a030642014fe5cfe68c2c0a818f9e3f522"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.9"
+version = "0.5.16"
 
 [[Markdown]]
-deps = ["Base64"]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
-
-[[MbedTLS_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "1.11.0"
 
 [[Missings]]
 deps = ["DataAPI"]
-git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
+git-tree-sha1 = "ec4f7fbeab05d7747bdf98eb74d130a2a2ed298d"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "1.0.2"
+version = "1.2.0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+version = "1.11.0"
 
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
 
 [[OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.7+0"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
 
 [[OpenSpecFun_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "1346c9208249809840c91b26703912dff463d335"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.5+0"
+version = "0.5.6+0"
 
 [[OrderedCollections]]
-git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+git-tree-sha1 = "94ba93778373a53bfd5a0caaf7d809c445292ff4"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.4.1"
+version = "1.8.2"
 
 [[PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "ee26b350276c51697c9c2d88a072b339f9f03d73"
+git-tree-sha1 = "26766d4b5f1a410c218a19b85a672c6edb693c65"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.5"
+version = "0.11.40"
+weakdeps = ["StatsBase"]
+
+    [PDMats.extensions]
+    StatsBaseExt = "StatsBase"
 
 [[Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+
+    [Pkg.extensions]
+    REPLExt = "REPL"
+
+    [Pkg.weakdeps]
+    REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
 
 [[Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.3"
+version = "1.5.2"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[PtrArrays]]
+git-tree-sha1 = "4fbbafbc6251b883f4d2705356f3641f3652a7fe"
+uuid = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
+version = "1.4.0"
 
 [[QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "78aadffb3efd2155af139781b8a8df1ef279ea39"
+git-tree-sha1 = "5e8e8b0ab68215d7a2b14b9921a946fee794749e"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.4.2"
+version = "2.11.3"
 
-[[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
-uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+    [QuadGK.extensions]
+    QuadGKEnzymeExt = "Enzyme"
+
+    [QuadGK.weakdeps]
+    Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -283,121 +437,176 @@ version = "1.2.0"
 
 [[Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
+git-tree-sha1 = "5b3d50eb374cea306873b371d3f8d3915a018f0b"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.7.0"
+version = "0.9.0"
 
 [[Rmath_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.3.0+0"
+version = "0.5.1+0"
+
+[[Roots]]
+deps = ["Accessors", "CommonSolve", "Printf"]
+git-tree-sha1 = "ed45bcc7cf3c8887595b973f2b1efbe91dcc50ec"
+uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
+version = "3.0.1"
+
+    [Roots.extensions]
+    RootsChainRulesCoreExt = "ChainRulesCore"
+    RootsForwardDiffExt = "ForwardDiff"
+    RootsIntervalRootFindingExt = "IntervalRootFinding"
+    RootsSymPyExt = "SymPy"
+    RootsSymPyPythonCallExt = "SymPyPythonCall"
+    RootsUnitfulExt = "Unitful"
+
+    [Roots.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    IntervalRootFinding = "d2bf35a9-74e0-55ec-b149-d360ff49b807"
+    SymPy = "24249f21-da20-56a4-8eb1-6a02cf4ae2e6"
+    SymPyPythonCall = "bc8888f7-b21e-4b7c-a06a-5d9c9496438c"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[SharedArrays]]
-deps = ["Distributed", "Mmap", "Random", "Serialization"]
-uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
-
-[[Sockets]]
-uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
 
 [[SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+git-tree-sha1 = "13cd91cc9be159e3f4d95b857fa2aa383b53772a"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.1"
+version = "1.2.3"
 
 [[SparseArrays]]
-deps = ["LinearAlgebra", "Random"]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
 
 [[SpecialFunctions]]
-deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "8d0c8e3d0ff211d9ff4a0c2307d876c99d10bdf1"
+deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "6547cbdd8ce32efba0d21c5a40fa96d1a3548f9f"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.2"
+version = "2.8.0"
+
+    [SpecialFunctions.extensions]
+    SpecialFunctionsChainRulesCoreExt = "ChainRulesCore"
+
+    [SpecialFunctions.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [[StableRNGs]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "3be7d49667040add7ee151fefaf1f8c04c8c8276"
+deps = ["Random"]
+git-tree-sha1 = "4f96c596b8c8258cc7d3b19797854d368f243ddc"
 uuid = "860ef19b-820b-49d6-a774-d7a799459cd3"
-version = "1.0.0"
+version = "1.0.4"
 
 [[Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+weakdeps = ["SparseArrays"]
+
+    [Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
 
 [[StatsAPI]]
-git-tree-sha1 = "d88665adc9bcf45903013af0982e2fd05ae3d0a6"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "178ed29fd5b2a2cfc3bd31c13375ae925623ff36"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.2.0"
+version = "1.8.0"
 
 [[StatsBase]]
-deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "118e8411d506d583fbbcf4f3a0e3c5a9e83370b8"
+deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.15"
+version = "0.34.12"
 
 [[StatsFuns]]
-deps = ["ChainRulesCore", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "f35e1879a71cca95f4826a14cdbf0b9e253ed918"
+deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "770240df9a3b8888065046948f7a09b4e0f997d5"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.9.15"
+version = "2.2.0"
+
+    [StatsFuns.extensions]
+    StatsFunsChainRulesCoreExt = "ChainRulesCore"
+    StatsFunsInverseFunctionsExt = "InverseFunctions"
+
+    [StatsFuns.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
+
+[[StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[SuiteSparse]]
 deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
 uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 
+[[SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
 [[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-
-[[Test]]
-deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
-uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.10.0"
 
 [[TranscodingStreams]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.6"
+version = "0.11.3"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[Wilsonloop]]
 deps = ["LaTeXStrings", "LinearAlgebra"]
-git-tree-sha1 = "a2c2d6ab953e131acf0db922453a6d5e01413f82"
+path = "/Users/akio/repository/Wilsonloop.jl"
 uuid = "f3c8d4fe-2f22-401d-8228-e6a01d7a1d02"
 version = "0.1.0"
 
 [[XML2_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "3f3315d89fc954a28f5b471bce698ed6e27481be"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
+version = "2.15.3+0"
 
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"
 
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
 
 [[p7zip_jll]]
-deps = ["Artifacts", "Libdl"]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"

--- a/src/Diracoperators.jl
+++ b/src/Diracoperators.jl
@@ -77,6 +77,10 @@ function Dirac_operator(U::Array{<: AbstractGaugefields{NC,Dim},1},x,parameters)
         Staggered_Dirac_operator(U,x,parameters)
     elseif parameters["Dirac_operator"] == "Wilson"
         Wilson_Dirac_operator(U,x,parameters)
+    elseif parameters["Dirac_operator"] == "WilsonClover"
+        clover_parameters = copy(parameters)
+        clover_parameters["hasclover"] = true
+        Wilson_Dirac_operator(U,x,clover_parameters)
     elseif parameters["Dirac_operator"] == "Wilson_general"
         Wilson_GeneralDirac_operator(U,x,parameters)
     elseif parameters["Dirac_operator"] == "Domainwall"
@@ -92,6 +96,10 @@ function DdagD_operator(U::Array{<: AbstractGaugefields{NC,Dim},1},x,parameters)
         DdagD_Staggered_operator(U,x,parameters)
     elseif parameters["Dirac_operator"] == "Wilson"
         DdagD_Wilson_operator(U,x,parameters)
+    elseif parameters["Dirac_operator"] == "WilsonClover"
+        clover_parameters = copy(parameters)
+        clover_parameters["hasclover"] = true
+        DdagD_Wilson_operator(U,x,clover_parameters)
     elseif parameters["Dirac_operator"] == "Domainwall"
         DdagD_Domainwall_operator(U,x,parameters)
     else

--- a/src/WilsonFermion/WilsonFermion.jl
+++ b/src/WilsonFermion/WilsonFermion.jl
@@ -119,7 +119,7 @@ function Wilson_Dirac_operator(U::Array{<: AbstractGaugefields{NC,Dim},1},x,para
 
     hasclover = check_parameters(parameters,"hasclover",false)
     if hasclover
-        error("notsupported")
+        cloverterm = WilsonClover(U,x,check_parameters(parameters,"cSW",check_parameters(parameters,"clover_coefficient",1.0)))
     else
         cloverterm = nothing
     end
@@ -152,7 +152,7 @@ function (D::Wilson_Dirac_operator{Dim,T,fermion})(U) where {Dim,T,fermion}
         D.hopm,
         D.eps_CG,D.MaxCGstep,D.verbose_level,
         D.method_CG,
-        D.cloverterm,
+        D.cloverterm === nothing ? nothing : WilsonClover(U,D._temporary_fermi[1],D.cloverterm.clover_coefficient),
         D.verbose_print,
         D._temporary_fermion_forCG
         )

--- a/src/WilsonFermion/WilsonFermion_4D.jl
+++ b/src/WilsonFermion/WilsonFermion_4D.jl
@@ -48,6 +48,7 @@ function Wx!(xout::T,U::Array{G,1},x::T,A)  where  {T <: WilsonFermion_4D,G <: A
 
     clear_fermion!(xout)
     add_fermion!(xout,1,x,-1,temp)
+    add_clover_term!(xout,A,x)
 
     set_wing_fermion!(xout,A.boundarycondition)
 
@@ -217,6 +218,7 @@ function Wdagx!(xout::T,U::Array{G,1},
 
     clear_fermion!(xout)
     add_fermion!(xout,1,x,-1,temp)
+    add_clover_term!(xout,A,x)
     set_wing_fermion!(xout,A.boundarycondition)
 
     #display(xout)

--- a/src/WilsonFermion/WilsonFermion_4D_wing.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_wing.jl
@@ -930,7 +930,7 @@ c--------------------------------------------------------------------------c
                         for i2=1:n2
                             #ix = i2+NDW
                             @simd for ic=1:NC
-                                x.f[i1,i2,i3,i4,i5,i6]=x.f[i1,i2,i3,i4,i5,i6]*ifelse(i6 <= 2,-1,1)
+                                x.f[ic,i2,i3,i4,i5,i6]=x.f[ic,i2,i3,i4,i5,i6]*ifelse(i6 <= 2,-1,1)
                             end
                         end
                     end

--- a/src/WilsonFermion/WilsoncloverFermion.jl
+++ b/src/WilsonFermion/WilsoncloverFermion.jl
@@ -1,3 +1,5 @@
+const CLOVER_DIRECTION_PAIRS = ((1,2),(1,3),(1,4),(2,3),(2,4),(3,4))
+
 struct WilsonClover
     clover_coefficient::Float64
     internal_flags::Array{Bool,1}
@@ -5,6 +7,8 @@ struct WilsonClover
     _ftmp_vectors::Array{Array{ComplexF64,3},1}
     _is1::Array{Int64,1}
     _is2::Array{Int64,1}
+    Fmunu::Array{ComplexF64,4}
+    sigma_munu::Array{ComplexF64,3}
 
     function WilsonClover(U::Array{<: AbstractGaugefields{NC,Dim},1},x,clover_coefficient) where {NC,Dim}
         _,_,NN... = size(U[1])
@@ -18,7 +22,160 @@ struct WilsonClover
 
         _is1 = zeros(Int64,NV)
         _is2 = zeros(Int64,NV)
+        Fmunu = zeros(ComplexF64,NC,NC,NV,6)
+        sigma_munu = clover_sigma_matrices()
 
-        return new(clover_coefficient,internal_flags,inn_table,_ftmp_vectors,_is1,_is2)
+        clover = new(clover_coefficient,internal_flags,inn_table,_ftmp_vectors,_is1,_is2,Fmunu,sigma_munu)
+        update_clover!(clover,U)
+        return clover
     end
+end
+
+function clover_sigma_matrices()
+    gamma,_,_ = mk_gamma(1.0)
+    sigma_munu = zeros(ComplexF64,4,4,6)
+    for (ipair,(mu,nu)) in enumerate(CLOVER_DIRECTION_PAIRS)
+        sigma_munu[:,:,ipair] .= 0.5 .* (gamma[:,:,mu] * gamma[:,:,nu] - gamma[:,:,nu] * gamma[:,:,mu])
+    end
+    return sigma_munu
+end
+
+@inline function _clover_shift(site::NTuple{4,Int},dir::Int,step::Int,dims::NTuple{4,Int})
+    shifted = (site[1],site[2],site[3],site[4])
+    value = mod(site[dir] - 1 + step,dims[dir]) + 1
+    if dir == 1
+        return (value,shifted[2],shifted[3],shifted[4])
+    elseif dir == 2
+        return (shifted[1],value,shifted[3],shifted[4])
+    elseif dir == 3
+        return (shifted[1],shifted[2],value,shifted[4])
+    else
+        return (shifted[1],shifted[2],shifted[3],value)
+    end
+end
+
+@inline function _clover_linear_site(site::NTuple{4,Int},dims::NTuple{4,Int})
+    ix,iy,iz,it = site
+    NX,NY,NZ,_ = dims
+    return (it-1)*NX*NY*NZ + (iz-1)*NX*NY + (iy-1)*NX + ix
+end
+
+function _clover_link_matrix(Udir,site::NTuple{4,Int})
+    NC = Udir.NC
+    ix,iy,iz,it = site
+    mat = Matrix{ComplexF64}(undef,NC,NC)
+    @inbounds for j=1:NC
+        for i=1:NC
+            mat[i,j] = Udir[i,j,ix,iy,iz,it]
+        end
+    end
+    return mat
+end
+
+function _clover_plaq(U,site::NTuple{4,Int},mu::Int,nu::Int,dims::NTuple{4,Int})
+    x = site
+    xpmu = _clover_shift(x,mu,1,dims)
+    xpnu = _clover_shift(x,nu,1,dims)
+    xmmu = _clover_shift(x,mu,-1,dims)
+    xmnu = _clover_shift(x,nu,-1,dims)
+    xmmu_pnu = _clover_shift(xmmu,nu,1,dims)
+    xmmu_mnu = _clover_shift(xmmu,nu,-1,dims)
+    xpmu_mnu = _clover_shift(xpmu,nu,-1,dims)
+
+    U_mu_x = _clover_link_matrix(U[mu],x)
+    U_nu_x = _clover_link_matrix(U[nu],x)
+    U_nu_xpmu = _clover_link_matrix(U[nu],xpmu)
+    U_mu_xpnu = _clover_link_matrix(U[mu],xpnu)
+    U_mu_xmmu = _clover_link_matrix(U[mu],xmmu)
+    U_nu_xmmu = _clover_link_matrix(U[nu],xmmu)
+    U_mu_xmnu = _clover_link_matrix(U[mu],xmnu)
+    U_nu_xmnu = _clover_link_matrix(U[nu],xmnu)
+    U_mu_xmmu_pnu = _clover_link_matrix(U[mu],xmmu_pnu)
+    U_nu_xmmu_mnu = _clover_link_matrix(U[nu],xmmu_mnu)
+    U_mu_xmmu_mnu = _clover_link_matrix(U[mu],xmmu_mnu)
+    U_nu_xpmu_mnu = _clover_link_matrix(U[nu],xpmu_mnu)
+
+    p1 = U_mu_x * U_nu_xpmu * U_mu_xpnu' * U_nu_x'
+    p2 = U_nu_x * U_mu_xmmu_pnu' * U_nu_xmmu' * U_mu_xmmu
+    p3 = U_mu_xmmu' * U_nu_xmmu_mnu' * U_mu_xmmu_mnu * U_nu_xmnu
+    p4 = U_nu_xmnu' * U_mu_xmnu * U_nu_xpmu_mnu * U_mu_x'
+
+    return p1 + p2 + p3 + p4
+end
+
+function _traceless_antihermitian_part(mat::AbstractMatrix{ComplexF64})
+    NC = size(mat,1)
+    fmat = 0.125 .* (mat - mat')
+    trace_part = tr(fmat) / NC
+    for i=1:NC
+        fmat[i,i] -= trace_part
+    end
+    return fmat
+end
+
+function update_clover!(clover::WilsonClover,U::Array{<: AbstractGaugefields{NC,4},1}) where NC
+    dims = (U[1].NX,U[1].NY,U[1].NZ,U[1].NT)
+    for it=1:dims[4]
+        for iz=1:dims[3]
+            for iy=1:dims[2]
+                for ix=1:dims[1]
+                    site = (ix,iy,iz,it)
+                    isite = _clover_linear_site(site,dims)
+                    for (ipair,(mu,nu)) in enumerate(CLOVER_DIRECTION_PAIRS)
+                        fmat = _traceless_antihermitian_part(_clover_plaq(U,site,mu,nu,dims))
+                        @inbounds for j=1:NC
+                            for i=1:NC
+                                clover.Fmunu[i,j,isite,ipair] = fmat[i,j]
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return clover
+end
+
+function add_clover_term!(xout,A,x)
+    clover = A.cloverterm
+    clover === nothing && return xout
+    coefficient = A.κ * clover.clover_coefficient
+    iszero(coefficient) && return xout
+
+    update_clover!(clover,A.U)
+
+    NX = x.NX
+    NY = x.NY
+    NZ = x.NZ
+    NT = x.NT
+    NC = x.NC
+    dims = (NX,NY,NZ,NT)
+
+    for it=1:NT
+        for iz=1:NZ
+            for iy=1:NY
+                for ix=1:NX
+                    isite = _clover_linear_site((ix,iy,iz,it),dims)
+                    for alpha=1:4
+                        for color_out=1:NC
+                            accum = zero(ComplexF64)
+                            for ipair=1:6
+                                for beta=1:4
+                                    spin_factor = clover.sigma_munu[alpha,beta,ipair]
+                                    if !iszero(spin_factor)
+                                        for color_in=1:NC
+                                            accum += clover.Fmunu[color_out,color_in,isite,ipair] *
+                                                spin_factor * x[color_in,ix,iy,iz,it,beta]
+                                        end
+                                    end
+                                end
+                            end
+                            xout[color_out,ix,iy,iz,it,alpha] += coefficient * accum
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return xout
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,9 @@ using LinearAlgebra
         @test true
     end
 
+    @testset "Wilson-clover checkpoints" begin
+        include("wilson_clover_operator_checkpoints.jl")
+    end
 
 
 

--- a/test/wilson_clover_operator_checkpoints.jl
+++ b/test/wilson_clover_operator_checkpoints.jl
@@ -1,0 +1,361 @@
+module WilsonCloverOperatorCheckpoints
+
+using Gaugefields
+using LatticeDiracOperators
+using LinearAlgebra
+using Random
+using SparseArrays
+using Test
+
+import Gaugefields: Initialize_4DGaugefields
+import LatticeDiracOperators.Dirac_operators: apply_γ5!
+
+const STRICT = get(ENV, "WILSON_CLOVER_STRICT", "1") != "0"
+const DEFAULT_KAPPA = 0.1
+const DEFAULT_RTOL = 1.0e-10
+
+function make_gauge(; NC = 3, L = 2, condition = "cold")
+    return Initialize_4DGaugefields(NC, 1, L, L, L, L; condition = condition)
+end
+
+function make_spinor(U; seed = 20260706)
+    x = Initialize_pseudofermion_fields(U[1], "Wilson")
+    Random.seed!(seed)
+    gauss_distribution_fermion!(x)
+    return x
+end
+
+function wilson_params(; kappa = DEFAULT_KAPPA)
+    return Dict{String,Any}(
+        "Dirac_operator" => "Wilson",
+        "κ" => kappa,
+        "verbose_level" => 1,
+    )
+end
+
+function clover_params(; cSW, kappa = DEFAULT_KAPPA)
+    params = wilson_params(; kappa = kappa)
+    params["hasclover"] = true
+    params["cSW"] = cSW
+    params["clover_coefficient"] = cSW
+    return params
+end
+
+function named_clover_params(; cSW, kappa = DEFAULT_KAPPA)
+    return Dict{String,Any}(
+        "Dirac_operator" => "WilsonClover",
+        "κ" => kappa,
+        "verbose_level" => 1,
+        "cSW" => cSW,
+    )
+end
+
+function coefficient_alias_params(; cSW, kappa = DEFAULT_KAPPA)
+    params = wilson_params(; kappa = kappa)
+    params["hasclover"] = true
+    params["clover_coefficient"] = cSW
+    return params
+end
+
+function try_construct_clover(U, x; cSW)
+    try
+        return Dirac_operator(U, x, clover_params(; cSW = cSW)), nothing
+    catch err
+        return nothing, err
+    end
+end
+
+function field_vector(x)
+    return ComplexF64[x[i] for i in 1:length(x)]
+end
+
+function l2norm_field(x)
+    return norm(field_vector(x))
+end
+
+function l2diff_field(x, y)
+    @assert length(x) == length(y)
+    return norm(field_vector(x) - field_vector(y))
+end
+
+function relative_field_error(x, y)
+    return l2diff_field(x, y) / max(l2norm_field(y), 1.0)
+end
+
+function relative_vector_field_error(v, y)
+    return norm(v - field_vector(y)) / max(norm(v), 1.0)
+end
+
+function apply_operator(D, x)
+    y = similar(x)
+    mul!(y, D, x)
+    return y
+end
+
+function apply_gamma5_copy(x)
+    y = deepcopy(x)
+    apply_γ5!(y)
+    return y
+end
+
+function require_clover_constructor()
+    U = make_gauge(; NC = 3, L = 2, condition = "cold")
+    x = make_spinor(U)
+    D, err = try_construct_clover(U, x; cSW = 0.0)
+
+    @testset "Wilson-clover constructor availability" begin
+        if D === nothing
+            if STRICT
+                @error "Wilson-clover constructor failed in strict mode" exception = (err, catch_backtrace())
+                @test D !== nothing
+            else
+                @info "Wilson-clover constructor is not implemented yet; non-strict mode stops here" err
+                @test D === nothing
+            end
+        else
+            @test D !== nothing
+        end
+    end
+
+    return D !== nothing
+end
+
+function test_csw_zero_regression(; NC = 3, condition = "hot")
+    U = make_gauge(; NC = NC, L = 2, condition = condition)
+    x = make_spinor(U; seed = 20260706 + NC)
+
+    Dwilson = Dirac_operator(U, x, wilson_params())
+    Dclover, err = try_construct_clover(U, x; cSW = 0.0)
+    @test Dclover !== nothing
+    Dclover === nothing && error(err)
+
+    yw = apply_operator(Dwilson, x)
+    yc = apply_operator(Dclover, x)
+    @test relative_field_error(yc, yw) < DEFAULT_RTOL
+
+    ywd = apply_operator(Dwilson', x)
+    ycd = apply_operator(Dclover', x)
+    @test relative_field_error(ycd, ywd) < DEFAULT_RTOL
+
+    DwDw = DdagD_operator(U, x, wilson_params())
+    DcDc = DdagD_operator(U, x, clover_params(; cSW = 0.0))
+    yww = apply_operator(DwDw, x)
+    ycc = apply_operator(DcDc, x)
+    @test relative_field_error(ycc, yww) < DEFAULT_RTOL
+end
+
+function test_identity_gauge_removes_clover(; NC = 3)
+    U = make_gauge(; NC = NC, L = 2, condition = "cold")
+    x = make_spinor(U; seed = 20260716 + NC)
+
+    Dwilson = Dirac_operator(U, x, wilson_params())
+    Dclover, err = try_construct_clover(U, x; cSW = 1.0)
+    @test Dclover !== nothing
+    Dclover === nothing && error(err)
+
+    yw = apply_operator(Dwilson, x)
+    yc = apply_operator(Dclover, x)
+    @test relative_field_error(yc, yw) < DEFAULT_RTOL
+end
+
+function test_clover_field_strength_diagnostics(; NC = 3)
+    Ucold = make_gauge(; NC = NC, L = 2, condition = "cold")
+    xcold = make_spinor(Ucold; seed = 20260718 + NC)
+    Dcold, errcold = try_construct_clover(Ucold, xcold; cSW = 1.0)
+    @test Dcold !== nothing
+    Dcold === nothing && error(errcold)
+    @test norm(Dcold.cloverterm.Fmunu) < DEFAULT_RTOL
+
+    Uhot = make_gauge(; NC = NC, L = 2, condition = "hot")
+    xhot = make_spinor(Uhot; seed = 20260719 + NC)
+    Dhot, errhot = try_construct_clover(Uhot, xhot; cSW = 1.0)
+    @test Dhot !== nothing
+    Dhot === nothing && error(errhot)
+
+    max_antihermitian_error = 0.0
+    max_trace_error = 0.0
+    for ipair in axes(Dhot.cloverterm.Fmunu, 4)
+        for isite in axes(Dhot.cloverterm.Fmunu, 3)
+            F = Dhot.cloverterm.Fmunu[:, :, isite, ipair]
+            max_antihermitian_error = max(max_antihermitian_error, norm(F + F'))
+            max_trace_error = max(max_trace_error, abs(tr(F)))
+        end
+    end
+
+    @test norm(Dhot.cloverterm.Fmunu) > 1.0e-12
+    @test max_antihermitian_error < DEFAULT_RTOL
+    @test max_trace_error < DEFAULT_RTOL
+end
+
+function test_hot_gauge_has_nonzero_clover_contribution(; NC = 3)
+    U = make_gauge(; NC = NC, L = 2, condition = "hot")
+    x = make_spinor(U; seed = 20260721 + NC)
+
+    D0, err0 = try_construct_clover(U, x; cSW = 0.0)
+    D1, err1 = try_construct_clover(U, x; cSW = 1.0)
+    @test D0 !== nothing
+    @test D1 !== nothing
+    D0 === nothing && error(err0)
+    D1 === nothing && error(err1)
+
+    y0 = apply_operator(D0, x)
+    y1 = apply_operator(D1, x)
+    @test relative_field_error(y1, y0) > 1.0e-12
+end
+
+function test_gamma5_hermiticity(; NC = 3)
+    U = make_gauge(; NC = NC, L = 2, condition = "hot")
+    x = make_spinor(U; seed = 20260726 + NC)
+
+    D, err = try_construct_clover(U, x; cSW = 0.7)
+    @test D !== nothing
+    D === nothing && error(err)
+
+    gx = apply_gamma5_copy(x)
+    lhs = apply_operator(D, gx)
+    apply_γ5!(lhs)
+
+    rhs = apply_operator(D', x)
+    @test relative_field_error(lhs, rhs) < 5.0e-10
+end
+
+function test_dag_d_positivity(; NC = 3)
+    U = make_gauge(; NC = NC, L = 2, condition = "hot")
+    x = make_spinor(U; seed = 20260736 + NC)
+
+    D, err = try_construct_clover(U, x; cSW = 0.5)
+    @test D !== nothing
+    D === nothing && error(err)
+
+    Dx = apply_operator(D, x)
+    DdagDx = apply_operator(D', Dx)
+    qform = dot(x, DdagDx)
+    dxnorm2 = dot(Dx, Dx)
+
+    @test abs(imag(qform)) < 5.0e-10 * max(abs(real(qform)), 1.0)
+    @test real(qform) >= -5.0e-10
+    @test abs(real(qform) - real(dxnorm2)) / max(abs(real(dxnorm2)), 1.0) < 5.0e-10
+end
+
+function test_sparse_matrix_roundtrip(; NC = 2)
+    U = make_gauge(; NC = NC, L = 2, condition = "hot")
+    x = make_spinor(U; seed = 20260746 + NC)
+
+    D, err = try_construct_clover(U, x; cSW = 0.5)
+    @test D !== nothing
+    D === nothing && error(err)
+
+    mat = construct_sparsematrix(D)
+    y = apply_operator(D, x)
+    yvec = mat * field_vector(x)
+    @test relative_vector_field_error(yvec, y) < DEFAULT_RTOL
+end
+
+function test_csw_linearity(; NC = 3)
+    U = make_gauge(; NC = NC, L = 2, condition = "hot")
+    x = make_spinor(U; seed = 20260756 + NC)
+
+    D0, err0 = try_construct_clover(U, x; cSW = 0.0)
+    D1, err1 = try_construct_clover(U, x; cSW = 0.25)
+    D2, err2 = try_construct_clover(U, x; cSW = 0.50)
+    @test D0 !== nothing
+    @test D1 !== nothing
+    @test D2 !== nothing
+    D0 === nothing && error(err0)
+    D1 === nothing && error(err1)
+    D2 === nothing && error(err2)
+
+    y0 = field_vector(apply_operator(D0, x))
+    y1 = field_vector(apply_operator(D1, x))
+    y2 = field_vector(apply_operator(D2, x))
+
+    c1 = y1 - y0
+    c2 = y2 - y0
+    @test norm(c2 - 2.0 .* c1) / max(norm(c2), 1.0) < 5.0e-10
+end
+
+function test_named_operator_and_parameter_aliases(; NC = 3)
+    U = make_gauge(; NC = NC, L = 2, condition = "hot")
+    x = make_spinor(U; seed = 20260766 + NC)
+
+    Dhasclover = Dirac_operator(U, x, clover_params(; cSW = 0.4))
+    Dnamed = Dirac_operator(U, x, named_clover_params(; cSW = 0.4))
+    Dcoefficient = Dirac_operator(U, x, coefficient_alias_params(; cSW = 0.4))
+
+    yhasclover = apply_operator(Dhasclover, x)
+    ynamed = apply_operator(Dnamed, x)
+    ycoefficient = apply_operator(Dcoefficient, x)
+
+    @test relative_field_error(ynamed, yhasclover) < DEFAULT_RTOL
+    @test relative_field_error(ycoefficient, yhasclover) < DEFAULT_RTOL
+
+    Nhasclover = DdagD_operator(U, x, clover_params(; cSW = 0.4))
+    Nnamed = DdagD_operator(U, x, named_clover_params(; cSW = 0.4))
+    @test relative_field_error(apply_operator(Nnamed, x), apply_operator(Nhasclover, x)) < DEFAULT_RTOL
+end
+
+function test_gauge_rebind_rebuilds_clover(; NC = 3)
+    Uhot = make_gauge(; NC = NC, L = 2, condition = "hot")
+    Ucold = make_gauge(; NC = NC, L = 2, condition = "cold")
+    x = make_spinor(Uhot; seed = 20260776 + NC)
+
+    Dhot = Dirac_operator(Uhot, x, clover_params(; cSW = 0.6))
+    Drebuilt = Dhot(Ucold)
+    Ddirect = Dirac_operator(Ucold, x, clover_params(; cSW = 0.6))
+
+    @test relative_field_error(apply_operator(Drebuilt, x), apply_operator(Ddirect, x)) < DEFAULT_RTOL
+end
+
+function run()
+    if !require_clover_constructor()
+        return
+    end
+
+    @testset "Wilson-clover cSW=0 regression" begin
+        for NC in (2, 3)
+            test_csw_zero_regression(; NC = NC, condition = "hot")
+        end
+    end
+
+    @testset "Wilson-clover identity gauge" begin
+        for NC in (2, 3)
+            test_identity_gauge_removes_clover(; NC = NC)
+        end
+    end
+
+    @testset "Wilson-clover field-strength diagnostics" begin
+        test_clover_field_strength_diagnostics(; NC = 3)
+    end
+
+    @testset "Wilson-clover nonzero hot-gauge contribution" begin
+        test_hot_gauge_has_nonzero_clover_contribution(; NC = 3)
+    end
+
+    @testset "Wilson-clover gamma5 hermiticity" begin
+        test_gamma5_hermiticity(; NC = 3)
+    end
+
+    @testset "Wilson-clover DdagD positivity" begin
+        test_dag_d_positivity(; NC = 3)
+    end
+
+    @testset "Wilson-clover sparse-matrix roundtrip" begin
+        test_sparse_matrix_roundtrip(; NC = 2)
+    end
+
+    @testset "Wilson-clover cSW linearity" begin
+        test_csw_linearity(; NC = 3)
+    end
+
+    @testset "Wilson-clover API aliases" begin
+        test_named_operator_and_parameter_aliases(; NC = 3)
+    end
+
+    @testset "Wilson-clover gauge rebind" begin
+        test_gauge_rebind_rebuilds_clover(; NC = 3)
+    end
+end
+
+end # module
+
+WilsonCloverOperatorCheckpoints.run()


### PR DESCRIPTION
## Summary

- Fix a Wilson 4D `apply_γ5!` color-index typo uncovered by gamma5-hermiticity testing.
- Enable the existing Wilson `hasclover=true` path by constructing a `WilsonClover` term.
- Add a `WilsonClover` operator alias and support both `cSW` and `clover_coefficient` parameters.
- Add a readable site-local clover contribution to the 4D Wilson apply paths.
- Build the clover field strength from explicit four-leaf plaquettes and project to the traceless anti-Hermitian part.
- Add Wilson-clover checkpoint tests and include them from `test/runtests.jl`.

## Root Cause

The bug fix is not clover-specific: `apply_γ5!` for `WilsonFermion_4D_wing` used the wrong index inside the color loop. That affects Wilson-family code paths that apply gamma5, including gamma5-hermiticity checks and `γ5D_operator` usage.

The clover implementation side was also incomplete: the repository already had a partial `WilsonClover` skeleton and a `cloverterm` field on `Wilson_Dirac_operator`, but `hasclover=true` stopped with `error("notsupported")`.

## Validation

Run on the local private checkout with Julia 1.12.4 using local `Gaugefields.jl` and `Wilsonloop.jl` paths:

```bash
WILSON_CLOVER_STRICT=1 julia --startup-file=no --compiled-modules=no --project=. test/wilson_clover_operator_checkpoints.jl
```

Passing checkpoint groups:

- constructor availability
- `cSW=0` regression
- identity gauge
- field-strength diagnostics
- nonzero hot-gauge clover contribution
- gamma5 hermiticity
- `DdagD` positivity
- sparse-matrix roundtrip
- `cSW` linearity
- API aliases
- gauge rebind

Also checked:

```bash
git diff --check
julia --startup-file=no --compiled-modules=no -e 'for f in ARGS; Meta.parseall(read(f,String)); println("parse ok ", f); end' test/runtests.jl test/wilson_clover_operator_checkpoints.jl src/WilsonFermion/WilsoncloverFermion.jl src/WilsonFermion/WilsonFermion.jl src/WilsonFermion/WilsonFermion_4D.jl src/WilsonFermion/WilsonFermion_4D_wing.jl src/Diracoperators.jl
```

## Notes

This is intentionally a readable reference-style clover implementation: the clover field is recomputed on operator application. Fermion force and production cache invalidation are left for follow-up work.
