### PR TITLE
[codex] Fix Wilson gamma5 application

### DIFF
--- a/src/WilsonFermion/WilsonFermion_4D_wing.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_wing.jl
@@ -930,7 +930,7 @@ c--------------------------------------------------------------------------c
                         for i2=1:n2
                             #ix = i2+NDW
                             @simd for ic=1:NC
-                                x.f[i1,i2,i3,i4,i5,i6]=x.f[i1,i2,i3,i4,i5,i6]*ifelse(i6 <= 2,-1,1)
+                                x.f[ic,i2,i3,i4,i5,i6]=x.f[ic,i2,i3,i4,i5,i6]*ifelse(i6 <= 2,-1,1)
                             end
                         end
                     end

--- a/test/gamma5.jl
+++ b/test/gamma5.jl
@@ -1,0 +1,32 @@
+using LatticeDiracOperators
+using Test
+
+import LatticeDiracOperators.Dirac_operators: apply_γ5!
+import LatticeDiracOperators.Dirac_operators: WilsonFermion_4D_wing
+
+function test_apply_gamma5_wilson4d()
+    x = WilsonFermion_4D_wing{3}(1,1,1,1)
+    original = similar(x.f)
+
+    for index in CartesianIndices(x.f)
+        value = complex(Float64(index[1] + 10index[2] + 100index[3] +
+                                1000index[4] + 10000index[5] + 100000index[6]),
+                        Float64(index[1] - index[6]))
+        x.f[index] = value
+        original[index] = value
+    end
+
+    apply_γ5!(x)
+
+    for index in CartesianIndices(x.f)
+        expected_sign = index[6] <= 2 ? -1 : 1
+        @test x.f[index] == expected_sign * original[index]
+    end
+
+    apply_γ5!(x)
+    @test x.f == original
+end
+
+@testset "Wilson gamma5" begin
+    test_apply_gamma5_wilson4d()
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,9 @@ using Test
 using LinearAlgebra
 
 @testset "LatticeDiracOperators.jl" begin
+    @testset "Gamma5 operations" begin
+        include("gamma5.jl")
+    end
     
     @testset "Staggered HMC" begin
         include("hmc.jl")


### PR DESCRIPTION
## Summary

- Fix `apply_γ5!` for `WilsonFermion_4D_wing` so the color loop updates `x.f[ic, ...]` instead of using an undefined/wrong index.
- Add a focused gamma5 unit test that checks every stored component is multiplied by the expected spin-dependent sign.
- Include the new gamma5 test from `test/runtests.jl`.

## Scope Note

This PR fixes the `WilsonFermion_4D_wing` path. In the usual `LatticeQCD.jl` Wilson setup, gauge fields are initialized with `Nwing`, but the Wilson pseudofermion is requested with `nowing=true`:

```julia
Initialize_pseudofermion_fields(U[1], "Wilson", nowing = true)
```

With the registered `LatticeDiracOperators.jl` v0.2.0 package, that route selects `WilsonFermion_4D_nowing`, not `WilsonFermion_4D_wing`. Therefore this PR should be read as a fix for the wing implementation; it does not claim that the default `LatticeQCD.jl` Wilson route exercises this exact method. The current private-copy branch differs from the registered package because its Wilson initialization currently falls back to the wing type.

The corresponding no-wing gamma5 path should be checked separately if the goal is to cover the default `LatticeQCD.jl` Wilson route.

## Root Cause

`apply_γ5!` iterates over color with `ic`, but the assignment used `i1` in the color slot. In this method `i1` is not the color-loop variable, so calling this gamma5 path can fail or update the wrong component.

## Validation

Focused test run on the local worktree with Julia 1.12.4:

```bash
JULIA_PKG_PRECOMPILE_AUTO=0 julia --startup-file=no --compiled-modules=no --project=. -e 'include("test/gamma5.jl")'
```

Result:

```text
Wilson gamma5 | 973/973 pass
```

Also checked:

```bash
git diff --check
julia --startup-file=no --compiled-modules=no -e 'for f in ARGS; Meta.parseall(read(f,String)); println("parse ok ", f); end' src/WilsonFermion/WilsonFermion_4D_wing.jl test/gamma5.jl test/runtests.jl
```
