### PR TITLE
Add validated Wilson-clover force and tests

### DIFF
--- a/src/Diracoperators.jl
+++ b/src/Diracoperators.jl
@@ -155,13 +155,13 @@ function Dirac_operator(
             end
         end
     elseif parameters["Dirac_operator"] == "WilsonClover"
-        @warn "not implemented completely!!"
         fasterversion = check_parameters(parameters, "faster version", false)
         if fasterversion
             @warn "The faster version is not supported but now \"faster version\" is true. We ignore it. "
         end
-        parameters["hasclover"] = true
-        Wilson_Dirac_operator(U, x, parameters)
+        clover_parameters = copy(parameters)
+        clover_parameters["hasclover"] = true
+        Wilson_Dirac_operator(U, x, clover_parameters)
     elseif parameters["Dirac_operator"] == "Wilson_general"
         Wilson_GeneralDirac_operator(U, x, parameters)
     elseif parameters["Dirac_operator"] == "Domainwall"
@@ -187,6 +187,10 @@ function DdagD_operator(
         DdagD_Staggered_operator(U, x, parameters)
     elseif parameters["Dirac_operator"] == "Wilson"
         DdagD_Wilson_operator(U, x, parameters)
+    elseif parameters["Dirac_operator"] == "WilsonClover"
+        clover_parameters = copy(parameters)
+        clover_parameters["hasclover"] = true
+        DdagD_Wilson_operator(U, x, clover_parameters)
     elseif parameters["Dirac_operator"] == "Domainwall"
         DdagD_Domainwall_operator(U, x, parameters)
     elseif parameters["Dirac_operator"] == "GeneralDirac"

--- a/src/WilsonFermion/WilsonFermion.jl
+++ b/src/WilsonFermion/WilsonFermion.jl
@@ -613,19 +613,7 @@ function Wx!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:AbstractGaugefiel
     set_wing_fermion!(xout, A.boundarycondition)
 
     if A.cloverterm != nothing
-        #clear_fermion!(xout) #debug
-        #println("xout ",sum(abs.(xout.f)))
-        #println(sum(abs.(x.f)))
-        #println(sum(abs.(xout.f)))
-
-        cloverterm_σμν!(xout, A.cloverterm, x, temp, temp2)
-        #println("after: ",dot(xout,xout))
-
-        #clear_fermion!(xout) #debug
-        #cloverterm!(xout,A.cloverterm,x)
-        #println(sum(abs.(xout.f)))
-        #error("dddd")
-        #add_fermion!(xout, 1, xout, 1, temp2)
+        add_clover_term!(xout, A, x)
     end
 
     set_wing_fermion!(xout, A.boundarycondition)
@@ -932,81 +920,9 @@ function Wdagx_noclover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstr
 end
 
 function Wdagx_clover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:AbstractGaugefields}
-    #,temps::Array{T,1},boundarycondition) where  {T <: WilsonFermion_4D,G <: AbstractGaugefields}
-    #temp = A._temporary_fermi[4] #temps[4]
-    #temp1 = A._temporary_fermi[1] #temps[1]
-    #temp2 = A._temporary_fermi[2] #temps[2]
-    temp, it_temp = get_temp(A._temporary_fermi)#[4] #temps[4]
-    temp1, it_temp1 = get_temp(A._temporary_fermi)#i[1] #temps[1]
-    temp2, it_temp2 = get_temp(A._temporary_fermi)#[2] #temps[2]
-
-
-
-    clear_fermion!(temp)
-    set_wing_fermion!(x, A.boundarycondition)
-    x5 = A._temporary_fermi[5]
-    mul_γ5x!(x5, x)
-    #set_wing_fermion!(x5)
-    set_wing_fermion!(x5, A.boundarycondition)
-
-    for ν = 1:Dim
-        xplus = shift_fermion(x5, ν)
-        mul!(temp1, U[ν], xplus)
-
-        #fermion_shift!(temp1,U,ν,x)
-
-        #... Dirac multiplication
-        #mul!(temp1,view(x.rminusγ,:,:,ν),temp1)
-        #mul!(temp1, view(A.rplusγ, :, :, ν))
-        mul!(temp1, A.rminusγ[:, :, ν])
-
-
-        #
-        xminus = shift_fermion(x5, -ν)
-        Uminus = shift_U(U[ν], -ν)
-
-        mul!(temp2, Uminus', xminus)
-        #fermion_shift!(temp2,U,-ν,x)
-        #mul!(temp2,view(x.rminusγ,:,:,ν),temp2)
-        #mul!(temp2, view(A.rminusγ, :, :, ν))
-        mul!(temp2, A.rplusγ[:, :, ν])
-
-
-        add_fermion!(temp, A.hopp[ν], temp1, A.hopm[ν], temp2)
-
-
-
-    end
-
-    clear_fermion!(temp1)
-    add_fermion!(temp1, 1, x5, -1, temp)
-    set_wing_fermion!(temp1, A.boundarycondition)
-    cloverterm_σμν!(temp1, A.cloverterm, x5, temp, temp2)
-    #println("before ",dot(temp1,temp1))
-    #println("x5 ",dot(x5,x5))
-    #clear_fermion!(temp1)
-    #for ix=1:4
-    #for i=1:6
-    #    println("clover $i $ix", A.cloverterm.CloverFμν[i][:,:,ix,1,1,1])
-    #end
-    #end
-    #error("dd")
-    #cloverterm!(temp1,A.cloverterm,x5)
-    #println("after ",dot(temp1,temp1))
-    #add_fermion!(temp, 1, temp1, 1, temp2)
-    #cloverterm!(temp1,A.cloverterm,x5)
-    #add_fermion!(xout, 1, x, -1, temp)
-    #mul_γ5x!(xout,temp)
-    mul_γ5x!(xout, temp1)
+    Wdagx_noclover!(xout, U, x, A, Dim)
+    add_clover_term!(xout, A, x)
     set_wing_fermion!(xout, A.boundarycondition)
-
-
-    unused!(A._temporary_fermi, it_temp)
-    unused!(A._temporary_fermi, it_temp1)
-    unused!(A._temporary_fermi, it_temp2)
-
-    #display(xout)
-    #    exit()
     return
 end
 

--- a/src/WilsonFermion/WilsoncloverFermion.jl
+++ b/src/WilsonFermion/WilsoncloverFermion.jl
@@ -1,329 +1,158 @@
+const CLOVER_DIRECTION_PAIRS = ((1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4))
 
-using Wilsonloop
-import Wilsonloop: make_cloverloops
-import Gaugefields: AbstractGaugefields_module.Antihermitian!
-
-struct WilsonClover{Dim,TG}
+struct WilsonClover
     cSW::Float64
-    cloverloops::Matrix{Vector{Wilsonline{Dim}}}
-    internal_flags::Array{Bool,1}
-    inn_table::Array{Int64,3}
-    _ftmp_vectors::Array{Array{ComplexF64,3},1}
-    _is1::Array{Int64,1}
-    _is2::Array{Int64,1}
-    CloverFμν::Vector{TG}
-    #CloverFμν::Array{ComplexF64,4}
-    temp_gaugefields::Vector{TG}
-    factor::Float64
-    #dcoverloopsdU::Matrix{Vector{Vector{Wilsonloop.DwDU{Dim}}}}
-    #dcoverloopsdagdU::Matrix{Vector{Vector{Wilsonloop.DwDU{Dim}}}}
-    #σ::Array{Array{ComplexF64,2},2}
+    clover_coefficient::Float64
+    Fmunu::Array{ComplexF64,4}
+    sigma_munu::Array{ComplexF64,3}
 end
-
 
 function WilsonClover(cSW, Dim, NV, U, hop)
-    #σ = make_σμν()
-    cloverloops = Matrix{Vector{Wilsonline{Dim}}}(undef, Dim, Dim)
+    @assert Dim == 4 "Wilson-clover is supported only in four dimensions"
+    NC = U[1].NC
+    expected_NV = U[1].NX * U[1].NY * U[1].NZ * U[1].NT
+    @assert NV == expected_NV "The fermion and gauge-field volumes must agree"
+    clover = WilsonClover(
+        Float64(cSW),
+        Float64(cSW),
+        zeros(ComplexF64, NC, NC, NV, length(CLOVER_DIRECTION_PAIRS)),
+        clover_sigma_matrices(),
+    )
+    update_clover!(clover, U)
+    return clover
+end
 
-    #dcloverloopsdU = Matrix{Vector{Vector{DwDU{Dim}}}}(undef,Dim,Dim)
-    #dcloverloopsdagdU = Matrix{Vector{Vector{DwDU{Dim}}}}(undef,Dim,Dim)
+function (D::WilsonClover)(U)
+    NC = U[1].NC
+    NV = U[1].NX * U[1].NY * U[1].NZ * U[1].NT
+    clover = WilsonClover(
+        D.cSW,
+        D.clover_coefficient,
+        zeros(ComplexF64, NC, NC, NV, length(CLOVER_DIRECTION_PAIRS)),
+        D.sigma_munu,
+    )
+    update_clover!(clover, U)
+    return clover
+end
 
+function clover_sigma_matrices()
+    gamma, _, _ = mk_gamma(1.0)
+    sigma_munu = zeros(ComplexF64, 4, 4, length(CLOVER_DIRECTION_PAIRS))
+    for (ipair, (mu, nu)) in enumerate(CLOVER_DIRECTION_PAIRS)
+        sigma_munu[:, :, ipair] .=
+            0.5 .* (gamma[:, :, mu] * gamma[:, :, nu] - gamma[:, :, nu] * gamma[:, :, mu])
+    end
+    return sigma_munu
+end
 
-    for μ = 1:Dim
-        for ν = 1:Dim
-            #loops = Wilsonline{Dim}[]
-            #loop_righttop = Wilsonline([(μ, 1), (ν, 1), (μ, -1), (ν, -1)])
-            #push!(loops, loop_righttop)
+@inline function _clover_shift(site::NTuple{4,Int}, dir::Int, step::Int, dims::NTuple{4,Int})
+    shifted = (site[1], site[2], site[3], site[4])
+    value = mod(site[dir] - 1 + step, dims[dir]) + 1
+    if dir == 1
+        return (value, shifted[2], shifted[3], shifted[4])
+    elseif dir == 2
+        return (shifted[1], value, shifted[3], shifted[4])
+    elseif dir == 3
+        return (shifted[1], shifted[2], value, shifted[4])
+    end
+    return (shifted[1], shifted[2], shifted[3], value)
+end
 
+@inline function _clover_linear_site(site::NTuple{4,Int}, dims::NTuple{4,Int})
+    ix, iy, iz, it = site
+    NX, NY, NZ, _ = dims
+    return (it - 1) * NX * NY * NZ + (iz - 1) * NX * NY + (iy - 1) * NX + ix
+end
 
-            cloverloops[μ, ν] = make_cloverloops(μ, ν; Dim=Dim)
-            #dcloverloopsdU[μ, ν] = Vector{Vector{DwDU{Dim}}}(undef,Dim) 
-            #dcloverloopsdagdU[μ, ν] = Vector{Vector{DwDU{Dim}}}(undef,Dim) 
-            #=
-            for μd=1:Dim
-                dcloverloopsdU[μ, ν][μd] =  DwDU{Dim}[]
-                dcloverloopsdagdU[μ, ν][μd] =  DwDU{Dim}[]
+function _clover_link_matrix(Udir, site::NTuple{4,Int})
+    NC = Udir.NC
+    ix, iy, iz, it = site
+    mat = Matrix{ComplexF64}(undef, NC, NC)
+    @inbounds for j = 1:NC, i = 1:NC
+        mat[i, j] = Udir[i, j, ix, iy, iz, it]
+    end
+    return mat
+end
+
+function _clover_plaquette_sum(U, site::NTuple{4,Int}, mu::Int, nu::Int, dims::NTuple{4,Int})
+    x = site
+    xpmu = _clover_shift(x, mu, 1, dims)
+    xpnu = _clover_shift(x, nu, 1, dims)
+    xmmu = _clover_shift(x, mu, -1, dims)
+    xmnu = _clover_shift(x, nu, -1, dims)
+    xmmu_pnu = _clover_shift(xmmu, nu, 1, dims)
+    xmmu_mnu = _clover_shift(xmmu, nu, -1, dims)
+    xpmu_mnu = _clover_shift(xpmu, nu, -1, dims)
+
+    U_mu_x = _clover_link_matrix(U[mu], x)
+    U_nu_x = _clover_link_matrix(U[nu], x)
+    U_nu_xpmu = _clover_link_matrix(U[nu], xpmu)
+    U_mu_xpnu = _clover_link_matrix(U[mu], xpnu)
+    U_mu_xmmu = _clover_link_matrix(U[mu], xmmu)
+    U_nu_xmmu = _clover_link_matrix(U[nu], xmmu)
+    U_mu_xmnu = _clover_link_matrix(U[mu], xmnu)
+    U_nu_xmnu = _clover_link_matrix(U[nu], xmnu)
+    U_mu_xmmu_pnu = _clover_link_matrix(U[mu], xmmu_pnu)
+    U_nu_xmmu_mnu = _clover_link_matrix(U[nu], xmmu_mnu)
+    U_mu_xmmu_mnu = _clover_link_matrix(U[mu], xmmu_mnu)
+    U_nu_xpmu_mnu = _clover_link_matrix(U[nu], xpmu_mnu)
+
+    p1 = U_mu_x * U_nu_xpmu * U_mu_xpnu' * U_nu_x'
+    p2 = U_nu_x * U_mu_xmmu_pnu' * U_nu_xmmu' * U_mu_xmmu
+    p3 = U_mu_xmmu' * U_nu_xmmu_mnu' * U_mu_xmmu_mnu * U_nu_xmnu
+    p4 = U_nu_xmnu' * U_mu_xmnu * U_nu_xpmu_mnu * U_mu_x'
+    return p1 + p2 + p3 + p4
+end
+
+function _traceless_antihermitian_part(mat::AbstractMatrix{ComplexF64})
+    NC = size(mat, 1)
+    out = 0.125 .* (mat - mat')
+    trace_part = tr(out) / NC
+    @inbounds for i = 1:NC
+        out[i, i] -= trace_part
+    end
+    return out
+end
+
+function update_clover!(clover::WilsonClover, U::Array{<:AbstractGaugefields{NC,4},1}) where NC
+    dims = (U[1].NX, U[1].NY, U[1].NZ, U[1].NT)
+    for it = 1:dims[4], iz = 1:dims[3], iy = 1:dims[2], ix = 1:dims[1]
+        site = (ix, iy, iz, it)
+        isite = _clover_linear_site(site, dims)
+        for (ipair, (mu, nu)) in enumerate(CLOVER_DIRECTION_PAIRS)
+            fmat = _traceless_antihermitian_part(_clover_plaquette_sum(U, site, mu, nu, dims))
+            @inbounds for j = 1:NC, i = 1:NC
+                clover.Fmunu[i, j, isite, ipair] = fmat[i, j]
             end
-
-            for μd=1:Dim
-                for loop in cloverloops[μ, ν]
-                    dU = derive_U(loop,μd)
-                    for dUi in dU
-                        #show(dUi)
-                        push!(dcloverloopsdU[μ, ν][μd] ,dUi)
-                    end
-                end
-                for loop in cloverloops[μ, ν]
-                    dU = derive_U(loop',μd)
-                    for dUi in dU
-                        #show(dUi)
-                        push!(dcloverloopsdagdU[μ, ν][μd] ,dUi)
-                    end
-                end
-            end
-            =#
         end
     end
-
-
-    #error("dd")
-
-
-    numtemp = 5
-    TG = eltype(U)
-    temp_gaugefields = Vector{TG}(undef, numtemp)
-    for i = 1:numtemp
-        temp_gaugefields[i] = similar(U[1])
-    end
-
-
-    inn_table = zeros(Int64, NV, 4, 2)
-    internal_flags = zeros(Bool, 2)
-    _ftmp_vectors = Array{Array{ComplexF64,3},1}(undef, 6)
-    _is1 = zeros(Int64, NV)
-    _is2 = zeros(Int64, NV)
-
-    factor = cSW * hop
-
-
-    CloverFμν = Make_CloverFμν(U, temp_gaugefields, cloverloops, factor)
-    #asum = 0.0
-    #=
-    asum2 = 0.0
-    temps = eltype(U)[]
-    ni = 4
-    for i=1:ni
-        push!(temps,similar(U[1]))
-    end
-    CloverFμν2 =  Gaugefields.make_Cloverloopterms(U,temps)
-
-    for i=1:length(CloverFμν)
-        asum += sum(abs.(CloverFμν[i].U))
-        asum2 += sum(abs.(CloverFμν2[i].U))*factor*0.125
-    end
-    println("sum(abs.(CloverFμν )) $asum $asum2")
-    =#
-
-
-    return WilsonClover{Dim,TG}(
-        cSW, cloverloops, internal_flags, inn_table, _ftmp_vectors, _is1, _is2, CloverFμν,
-        temp_gaugefields, factor)#,dcloverloopsdU,dcoverloopsdagdU)
-    #return new(cSW, σ)
+    return clover
 end
 
-function (D::WilsonClover{Dim,TG})(U) where {Dim,TG}
-    Make_CloverFμν!(D.CloverFμν, U, D.temp_gaugefields, D.cloverloops, D.factor)
-    #println("clover $(sum(abs.(D.CloverFμν[1].U)))")
-    #println("U ",sum(abs.(U[1].U)))
-    return WilsonClover{Dim,TG}(
-        D.cSW, D.cloverloops, D.internal_flags, D.inn_table, D._ftmp_vectors, D._is1, D._is2, D.CloverFμν,
-        D.temp_gaugefields, D.factor)
-end
+function add_clover_term!(xout, A, x)
+    clover = A.cloverterm
+    clover === nothing && return xout
+    coefficient = A.κ * clover.clover_coefficient
+    iszero(coefficient) && return xout
 
-
-
-
-function Make_CloverFμν(U::Array{<:AbstractGaugefields{NC,Dim},1}, temps::Vector{T}, cloverloops, factor) where {T,NC,Dim}
-    NV = temps[1].NV
-    CloverFμν = Vector{T}(undef, 6)
-    for μν = 1:6
-        CloverFμν[μν] = similar(U[1])
-    end
-    #CloverFμν = zeros(ComplexF64,NC,NC,NV,6)
-    Make_CloverFμν!(CloverFμν, U, temps, cloverloops, factor)
-    return CloverFμν
-end
-
-function Make_CloverFμν!(CloverFμν, U::Array{<:AbstractGaugefields{NC,Dim},1}, temps, cloverloops, factor) where {NC,Dim}
-    @assert Dim == 4 "Only Dim = 4 case is supported. Now Dim = $Dim"
-    work1 = temps[4]
-    work2 = temps[5]
-
-    coe = im * 0.125 * factor
-
-    # ... Calculation of 4 leaves under the counter clock order.
-    μν = 0
-    for μ = 1:3
-        for ν = μ+1:4
-            μν += 1
-            if μν > 6
-                error("μν > 6 ?")
-            end
-
-            loops = cloverloops[μ, ν]
-
-            evaluate_gaugelinks!(work1, loops, U, temps)
-            #println(coe)
-            #for i=1:4
-            #    println("work1 ",work1[:,:,i,1,1,1],"\n")
-            #end
-            #Antihermitian!(CloverFμν[μν],work1,factor=coe) #work - work^+
-
-            Antihermitian!(work2, work1) #work - work^+
-            mul!(CloverFμν[μν], coe, work2)
-            #for i=1:4
-            #    println("c1 ",CloverFμν[μν][:,:,i,1,1,1],"\n")
-            #end
-            #substitute_U!(CloverFμν[μν],work1)
-
-            #loopset = Loops(U,fparam._cloverloops[μ,ν],[work2,work3,work4])
-            #evaluate_loops!(work1,loopset,U)
-            #setFμν!(CloverFμν,μν,work1)
-
-        end
-    end
-    #error("clover")
-
-
-
-end
-
-
-
-function make_σμν()
-    σ = Array{Array{ComplexF64,2},2}(undef, 4, 4)
-    for μ = 1:4
-        γμ = γ_all[:, :, μ]
-        for ν = 1:4
-            γν = γ_all[:, :, ν]
-            σ[μ, ν] = (γμ * γν .- γν * γμ) * (1 / 2)
-        end
-    end
-    return σ
-end
-
-
-
-"""
-    cloverterm_σμν!(vec,cloverterm,x,temp1,temp2)
-
-TBW
-"""
-function cloverterm_σμν!(vec, cloverterm, x, temp1, temp2)
-    μν = 0
-    clear_fermion!(temp1)
-    clear_fermion!(temp2)
-    #println("x ",sum(abs.(x.f)))
-    #println("vec ",sum(abs.(vec.f)))
-    for μ = 1:3
-        for ν = μ+1:4
-            μν += 1
-            #println("$μν $(sum(abs.(cloverterm.CloverFμν[μν].U)))")
-
-            #println("clovr  ",sum(abs.(cloverterm.CloverFμν[μν].U)))
-            mul!(temp1, cloverterm.CloverFμν[μν], x)
-            #println("ff1 ",sum(abs.(temp1.f)))
-            apply_σμν!(temp2, μ, ν, temp1)
-            #println("ff2 ",sum(abs.(temp2.f)))
-            #apply_σμν!(temp1,μ,ν,x)
-            #println(sum(abs.(cloverterm.CloverFμν[μν].U)))
-            #mul!(temp2,cloverterm.CloverFμν[μν],temp1)
-            #println("ffd ",sum(abs.(vec.f)))
-            add_fermion!(vec, 1, temp2)
-            #println("ffc ",sum(abs.(vec.f)))
-        end
-    end
-    #println("ff ",sum(abs.(vec.f)))
-    set_wing_fermion!(vec)
-    #println("ffvv ",sum(abs.(vec.f)))
-end
-
-
-function cloverterm!(vec, cloverterm, x)
-    NT = x.NT
-    NZ = x.NZ
-    NY = x.NY
-    NX = x.NX
+    update_clover!(clover, A.U)
+    dims = (x.NX, x.NY, x.NZ, x.NT)
     NC = x.NC
-    CloverFμν = cloverterm.CloverFμν
-
-
-
-    i = 0
-    for it = 1:NT
-        for iz = 1:NZ
-            for iy = 1:NY
-                for ix = 1:NX
-                    i += 1
-                    for k1 = 1:NC
-                        for k2 = 1:NC
-
-                            c1 = x[k2, ix, iy, iz, it, 1]
-                            c2 = x[k2, ix, iy, iz, it, 2]
-                            c3 = x[k2, ix, iy, iz, it, 3]
-                            c4 = x[k2, ix, iy, iz, it, 4]
-
-                            vec[k1, ix, iy, iz, it, 1] += CloverFμν[1][k1, k2, ix, iy, iz, it] * (-c1) +
-                                                          +CloverFμν[2][k1, k2, ix, iy, iz, it] * (-im * c2) +
-                                                          +CloverFμν[3][k1, k2, ix, iy, iz, it] * (-c2) +
-                                                          +CloverFμν[4][k1, k2, ix, iy, iz, it] * (-c2) +
-                                                          +CloverFμν[5][k1, k2, ix, iy, iz, it] * (im * c2) +
-                                                          +CloverFμν[6][k1, k2, ix, iy, iz, it] * (-c1)
-
-
-
-                            vec[k1, ix, iy, iz, it, 2] += CloverFμν[1][k1, k2, ix, iy, iz, it] * (c2) +
-                                                          +CloverFμν[2][k1, k2, ix, iy, iz, it] * (im * c1) +
-                                                          +CloverFμν[3][k1, k2, ix, iy, iz, it] * (-c1) +
-                                                          +CloverFμν[4][k1, k2, ix, iy, iz, it] * (-c1) +
-                                                          +CloverFμν[5][k1, k2, ix, iy, iz, it] * (-im * c1) +
-                                                          +CloverFμν[6][k1, k2, ix, iy, iz, it] * (c2)
-
-                            vec[k1, ix, iy, iz, it, 3] += CloverFμν[1][k1, k2, ix, iy, iz, it] * (-c3) +
-                                                          +CloverFμν[2][k1, k2, ix, iy, iz, it] * (-im * c4) +
-                                                          +CloverFμν[3][k1, k2, ix, iy, iz, it] * (c4) +
-                                                          +CloverFμν[4][k1, k2, ix, iy, iz, it] * (-c4) +
-                                                          +CloverFμν[5][k1, k2, ix, iy, iz, it] * (-im * c4) +
-                                                          +CloverFμν[6][k1, k2, ix, iy, iz, it] * (c3)
-
-                            vec[k1, ix, iy, iz, it, 4] += CloverFμν[1][k1, k2, ix, iy, iz, it] * (c4) +
-                                                          +CloverFμν[2][k1, k2, ix, iy, iz, it] * (im * c3) +
-                                                          +CloverFμν[3][k1, k2, ix, iy, iz, it] * (c3) +
-                                                          +CloverFμν[4][k1, k2, ix, iy, iz, it] * (-c3) +
-                                                          +CloverFμν[5][k1, k2, ix, iy, iz, it] * (im * c3) +
-                                                          +CloverFμν[6][k1, k2, ix, iy, iz, it] * (-c4)
-
-
-                        end
+    for it = 1:x.NT, iz = 1:x.NZ, iy = 1:x.NY, ix = 1:x.NX
+        isite = _clover_linear_site((ix, iy, iz, it), dims)
+        for alpha = 1:4, color_out = 1:NC
+            accum = zero(ComplexF64)
+            for ipair = 1:length(CLOVER_DIRECTION_PAIRS), beta = 1:4
+                spin_factor = clover.sigma_munu[alpha, beta, ipair]
+                if !iszero(spin_factor)
+                    for color_in = 1:NC
+                        accum += clover.Fmunu[color_out, color_in, isite, ipair] *
+                                 spin_factor * x[color_in, ix, iy, iz, it, beta]
                     end
                 end
             end
-
+            xout[color_out, ix, iy, iz, it, alpha] += coefficient * accum
         end
     end
-
-    #println("vec = ",vec*vec)
-
-end
-
-
-
-
-struct WilsonClover_misc
-    clover_coefficient::Float64
-    internal_flags::Array{Bool,1}
-    inn_table::Array{Int64,3}
-    _ftmp_vectors::Array{Array{ComplexF64,3},1}
-    _is1::Array{Int64,1}
-    _is2::Array{Int64,1}
-
-    function WilsonClover(
-        U::Array{<:AbstractGaugefields{NC,Dim},1},
-        x,
-        clover_coefficient,
-    ) where {NC,Dim}
-        _, _, NN... = size(U[1])
-        NV = prod(NN)
-        inn_table = zeros(Int64, NV, 4, 2)
-        internal_flags = zeros(Bool, 2)
-        _ftmp_vectors = Array{Array{ComplexF64,3},1}(undef, 6)
-        for i = 1:6
-            _ftmp_vectors[i] = zeros(ComplexF64, NC, NV, 4)
-        end
-
-        _is1 = zeros(Int64, NV)
-        _is2 = zeros(Int64, NV)
-
-        return new(clover_coefficient, internal_flags, inn_table, _ftmp_vectors, _is1, _is2)
-    end
+    return xout
 end

--- a/src/action/WilsonFermiAction.jl
+++ b/src/action/WilsonFermiAction.jl
@@ -1,7 +1,6 @@
 import Gaugefields: Traceless_antihermitian_add!, Generator
 import Gaugefields.Temporalfields_module: Temporalfields, unused!, get_temp
 
-
 #include("clover_data.jl")
 
 abstract type Wilsontype_FermiAction{Dim,Dirac,fermion,gauge} <:
@@ -55,6 +54,7 @@ struct WilsonFermiAction{Dim,Dirac,fermion,gauge,hascloverterm} <:
         x, it_x = get_temp(D._temporary_fermi)
 
         xtype = typeof(x)
+        unused!(D._temporary_fermi, it_x)
         _temporary_fermionfields = Temporalfields(x; num)# Array{xtype,1}(undef, num)
         #for i = 1:num
         #    _temporary_fermionfields[i] = similar(x)
@@ -95,6 +95,212 @@ function evaluate_FermiAction(
     unused!(fermi_action._temporary_fermionfields, it_eta)
     return real(Sf)
 end
+
+function _sun_generator_matrices_for_clover_force(NC)
+    if NC == 2
+        return Matrix{ComplexF64}[
+            ComplexF64[0 1; 1 0],
+            ComplexF64[0 -im; im 0],
+            ComplexF64[1 0; 0 -1],
+        ]
+    elseif NC == 3
+        return Matrix{ComplexF64}[
+            ComplexF64[0 1 0; 1 0 0; 0 0 0],
+            ComplexF64[0 -im 0; im 0 0; 0 0 0],
+            ComplexF64[1 0 0; 0 -1 0; 0 0 0],
+            ComplexF64[0 0 1; 0 0 0; 1 0 0],
+            ComplexF64[0 0 -im; 0 0 0; im 0 0],
+            ComplexF64[0 0 0; 0 0 1; 0 1 0],
+            ComplexF64[0 0 0; 0 0 -im; 0 im 0],
+            (1 / sqrt(3)) .* ComplexF64[1 0 0; 0 1 0; 0 0 -2],
+        ]
+    end
+
+    generators = Matrix{ComplexF64}[]
+    sigma = Matrix{ComplexF64}[
+        ComplexF64[0 1; 1 0],
+        ComplexF64[0 -im; im 0],
+    ]
+    for i = 1:NC, j = i+1:NC
+        for pauli in sigma
+            lambda = zeros(ComplexF64, NC, NC)
+            lambda[i, i] = pauli[1, 1]
+            lambda[i, j] = pauli[1, 2]
+            lambda[j, i] = pauli[2, 1]
+            lambda[j, j] = pauli[2, 2]
+            lambda ./= sqrt(real(tr(lambda * lambda)) / 2)
+            push!(generators, lambda)
+        end
+    end
+    for a = 1:NC-1
+        lambda = zeros(ComplexF64, NC, NC)
+        for i = 1:a
+            lambda[i, i] = 1
+        end
+        lambda[a+1, a+1] = -tr(lambda)
+        lambda ./= sqrt(real(tr(lambda * lambda)) / 2)
+        push!(generators, lambda)
+    end
+    return generators
+end
+
+function _add_generator_component_to_force_matrix!(force_mu, generator, coefficient, site)
+    ix, iy, iz, it = site
+    NC = size(generator, 1)
+    @inbounds for j = 1:NC, i = 1:NC
+        force_mu[i, j, ix, iy, iz, it] += coefficient * (im / 2) * generator[i, j]
+    end
+    return force_mu
+end
+
+function _traceless_antihermitian_unscaled(mat::AbstractMatrix{ComplexF64})
+    NC = size(mat, 1)
+    out = mat - mat'
+    trace_part = tr(out) / NC
+    @inbounds for i = 1:NC
+        out[i, i] -= trace_part
+    end
+    return out
+end
+
+function _clover_color_source_matrix(X, Y, sigma_munu, site, ipair, NC)
+    ix, iy, iz, it = site
+    source = zeros(ComplexF64, NC, NC)
+    @inbounds for b = 1:NC, a = 1:NC
+        accum = zero(ComplexF64)
+        for alpha = 1:4
+            yconj = conj(Y[a, ix, iy, iz, it, alpha])
+            for beta = 1:4
+                spin_factor = sigma_munu[alpha, beta, ipair]
+                if !iszero(spin_factor)
+                    accum += spin_factor * X[b, ix, iy, iz, it, beta] * yconj
+                end
+            end
+        end
+        source[b, a] = accum
+    end
+    return source
+end
+
+function _clover_R_source_matrix(X, Y, clover, site, ipair, NC, kappa)
+    source = _clover_color_source_matrix(X, Y, clover.sigma_munu, site, ipair, NC)
+    return -(kappa * clover.clover_coefficient / 4) .*
+           _traceless_antihermitian_unscaled(source)
+end
+
+function _identity_color_matrix(NC)
+    eye = zeros(ComplexF64, NC, NC)
+    @inbounds for i = 1:NC
+        eye[i, i] = 1
+    end
+    return eye
+end
+
+function _clover_factor_product(factors, first, last, NC)
+    product = _identity_color_matrix(NC)
+    for i = first:last
+        product = product * factors[i].mat
+    end
+    return product
+end
+
+function _clover_link_factor(U, dir, site, dagger)
+    link = _clover_link_matrix(U[dir], site)
+    return (dir=dir, site=site, dagger=dagger, mat=dagger ? link' : link)
+end
+
+function _clover_plaquette_factor_terms(U, site, mu, nu, dims)
+    x = site
+    xpmu = _clover_shift(x, mu, 1, dims)
+    xpnu = _clover_shift(x, nu, 1, dims)
+    xmmu = _clover_shift(x, mu, -1, dims)
+    xmnu = _clover_shift(x, nu, -1, dims)
+    xmmu_pnu = _clover_shift(xmmu, nu, 1, dims)
+    xmmu_mnu = _clover_shift(xmmu, nu, -1, dims)
+    xpmu_mnu = _clover_shift(xpmu, nu, -1, dims)
+
+    return (
+        (
+            _clover_link_factor(U, mu, x, false),
+            _clover_link_factor(U, nu, xpmu, false),
+            _clover_link_factor(U, mu, xpnu, true),
+            _clover_link_factor(U, nu, x, true),
+        ),
+        (
+            _clover_link_factor(U, nu, x, false),
+            _clover_link_factor(U, mu, xmmu_pnu, true),
+            _clover_link_factor(U, nu, xmmu, true),
+            _clover_link_factor(U, mu, xmmu, false),
+        ),
+        (
+            _clover_link_factor(U, mu, xmmu, true),
+            _clover_link_factor(U, nu, xmmu_mnu, true),
+            _clover_link_factor(U, mu, xmmu_mnu, false),
+            _clover_link_factor(U, nu, xmnu, false),
+        ),
+        (
+            _clover_link_factor(U, nu, xmnu, true),
+            _clover_link_factor(U, mu, xmnu, false),
+            _clover_link_factor(U, nu, xpmu_mnu, false),
+            _clover_link_factor(U, mu, x, true),
+        ),
+    )
+end
+
+function _clover_link_gradients(K, generators)
+    return (real(tr(((im / 2) .* generator) * K)) for generator in generators)
+end
+
+function _accumulate_clover_plaquette_term!(destination, factors, Rsrc, generators, coeff, raw)
+    NC = size(Rsrc, 1)
+    for ifactor = 1:length(factors)
+        factor = factors[ifactor]
+        left = _clover_factor_product(factors, 1, ifactor - 1, NC)
+        right = _clover_factor_product(factors, ifactor + 1, length(factors), NC)
+        K = factor.dagger ?
+            -right * Rsrc * left * factor.mat :
+            factor.mat * right * Rsrc * left
+        for (igen, gradient) in enumerate(_clover_link_gradients(K, generators))
+            if raw
+                _add_generator_component_to_force_matrix!(
+                    destination[factor.dir], generators[igen], coeff * gradient, factor.site)
+            else
+                ix, iy, iz, it = factor.site
+                destination[factor.dir][igen, ix, iy, iz, it] += coeff * gradient
+            end
+        end
+    end
+    return destination
+end
+
+function _calc_clover_force_fromX!(destination, Y, W, U, X; coeff=1, raw=false)
+    clover = W.cloverterm
+    clover === nothing && return destination
+    NC = U[1].NC
+    generators = _sun_generator_matrices_for_clover_force(NC)
+    if !raw && length(generators) != destination[1].NumofBasis
+        error("Number of SU($NC) generators does not match momentum basis")
+    end
+
+    dims = (U[1].NX, U[1].NY, U[1].NZ, U[1].NT)
+    for it = 1:dims[4], iz = 1:dims[3], iy = 1:dims[2], ix = 1:dims[1]
+        site = (ix, iy, iz, it)
+        for (ipair, (mu, nu)) in enumerate(CLOVER_DIRECTION_PAIRS)
+            Rsrc = _clover_R_source_matrix(X, Y, clover, site, ipair, NC, W.κ)
+            for factors in _clover_plaquette_factor_terms(U, site, mu, nu, dims)
+                _accumulate_clover_plaquette_term!(
+                    destination, factors, Rsrc, generators, coeff, raw)
+            end
+        end
+    end
+    return destination
+end
+
+calc_p_UdSfdU_clover_fromX!(p, Y, W, U, X; coeff=1) =
+    _calc_clover_force_fromX!(p, Y, W, U, X; coeff=coeff, raw=false)
+
+calc_UdSfdU_clover_fromX!(force, Y, W, U, X; coeff=1) =
+    _calc_clover_force_fromX!(force, Y, W, U, X; coeff=coeff, raw=true)
 
 function calc_UdSfdU!(
     UdSfdU::Vector{<:AbstractGaugefields},
@@ -155,14 +361,6 @@ function calc_UdSfdU_fromX!(
     temp0_g, it_temp0_g = get_temp(fermi_action._temporary_gaugefields)
     #temp0_g = fermi_action._temporary_gaugefields[1]
 
-    if hascloverterm
-        D = fermi_action.diracoperator
-        hop = D.κ
-        Clover_coefficient = D.cloverterm.cSW
-        coe = im * 0.125 * hop * Clover_coefficient
-    end
-
-
     for μ = 1:Dim
         #!  Construct U(x,mu)*P1
 
@@ -214,14 +412,10 @@ function calc_UdSfdU_fromX!(
 
         add_U!(UdSfdU[μ], coeff, temp0_g)
 
-        if hascloverterm
-            clear_U!(temp0_g)
-            dSclover!(temp0_g, μ, X, Y, U, fermi_action)
-            #println(sum(abs.(temp0_g.U)))
-            add_U!(UdSfdU[μ], -coeff * 0, temp0_g)
-            #add!(p[μ],-τ*mdparams.Δτ,c)
-        end
+    end
 
+    if hascloverterm
+        calc_UdSfdU_clover_fromX!(UdSfdU, Y, W, U, X; coeff=coeff)
     end
 
     unused!(fermi_action._temporary_fermionfields, it_temp0_f)
@@ -243,8 +437,8 @@ function calc_p_UdSfdU!(
     #println("------dd")
     W = fermi_action.diracoperator(U)
     WdagW = DdagD_Wilson_operator(W)
-    X = fermi_action._temporary_fermionfields[end]
-    Y = fermi_action._temporary_fermionfields[2]
+    X, it_X = get_temp(fermi_action._temporary_fermionfields)
+    Y, it_Y = get_temp(fermi_action._temporary_fermionfields)
     #X = (D^dag D)^(-1) ϕ 
     #
     #println("Xd ",X[1,1,1,1,1,1])
@@ -253,6 +447,8 @@ function calc_p_UdSfdU!(
     #clear_U!(UdSfdU)
 
     calc_p_UdSfdU_fromX!(p, Y, fermi_action, U, X, coeff=coeff)
+    unused!(fermi_action._temporary_fermionfields, it_X)
+    unused!(fermi_action._temporary_fermionfields, it_Y)
     #println("----aa--")
     #set_wing_U!(UdSfdU)
 end
@@ -269,9 +465,9 @@ function calc_p_UdSfdU_fromX!(
     mul!(Y, W, X)
     #set_wing_fermion!(Y)
 
-    temp0_f = fermi_action._temporary_fermionfields[3]
-    temp1_f = fermi_action._temporary_fermionfields[4]
-    temp0_g = fermi_action._temporary_gaugefields[1]
+    temp0_f, it_temp0_f = get_temp(fermi_action._temporary_fermionfields)
+    temp1_f, it_temp1_f = get_temp(fermi_action._temporary_fermionfields)
+    temp0_g, it_temp0_g = get_temp(fermi_action._temporary_gaugefields)
 
     for μ = 1:Dim
         #!  Construct U(x,mu)*P1
@@ -329,6 +525,13 @@ function calc_p_UdSfdU_fromX!(
 
     end
 
+    if hascloverterm
+        calc_p_UdSfdU_clover_fromX!(p, Y, W, U, X; coeff=coeff)
+    end
+
+    unused!(fermi_action._temporary_fermionfields, it_temp0_f)
+    unused!(fermi_action._temporary_fermionfields, it_temp1_f)
+    unused!(fermi_action._temporary_gaugefields, it_temp0_g)
 
 end
 
@@ -776,7 +979,6 @@ function dSclover!(z, μ, X, Y, U, fermi_action::WilsonFermiAction{Dim,Dirac,
 
 
     end
-
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,10 @@ using LinearAlgebra
 
 @testset "LatticeDiracOperators.jl" begin
 
+    @testset "Wilson-clover" begin
+        include("wilson_clover.jl")
+    end
+
     @testset "Wilson HMC" begin
         println("Wilson HMC")
         include("wilsonhmc.jl")

--- a/test/wilson_clover.jl
+++ b/test/wilson_clover.jl
@@ -14,8 +14,26 @@ const KAPPA = 0.08
 const FORCE_EPSILON = 1.0e-6
 
 function make_gauge(NC; L=2, condition="hot", seed=2026071601)
-    Random.seed!(seed + NC + L)
-    return Initialize_4DGaugefields(NC, 0, L, L, L, L; condition=condition)
+    U = Initialize_4DGaugefields(NC, 0, L, L, L, L; condition="cold")
+    condition == "cold" && return U
+    condition == "hot" || error("unsupported condition: $condition")
+
+    tangent = initialize_TA_Gaugefields(U)
+    clear_U!(tangent)
+    phase = 0.001 * (seed % 1000)
+    for mu in eachindex(U), it in 1:L, iz in 1:L, iy in 1:L, ix in 1:L
+        for igen in 1:(NC^2 - 1)
+            tangent[mu][igen, ix, iy, iz, it] =
+                0.18 * sin(phase + 0.31igen + 0.47mu + 0.19ix + 0.23iy + 0.29iz + 0.37it)
+        end
+    end
+    for mu in eachindex(U)
+        expU, temp1, temp2 = (similar(U[mu]) for _ in 1:3)
+        exptU!(expU, 1.0, tangent[mu], [temp1, temp2])
+        substitute_U!(U[mu], expU)
+    end
+    set_wing_U!(U)
+    return U
 end
 
 function make_spinor(U; seed=2026071602)
@@ -158,15 +176,17 @@ function test_force(NC; L=1, all_generators=true)
 
     generators = LDO._sun_generator_matrices_for_clover_force(NC)
     generator_indices = all_generators ? eachindex(generators) : 1:1
-    site = (1, 1, 1, 1)
-    mu = 1
-    for igen in generator_indices
+    sites = L == 1 ? ((1, 1, 1, 1),) : ((1, 1, 1, 1), (2, 1, 2, 1))
+    directions = L == 1 ? (1,) : eachindex(U)
+    for site in sites, mu in directions, igen in generator_indices
         finite_difference = fixed_xy_finite_difference(action, U, X, Y, mu, igen, site)
         @test p[mu][igen, site...] ≈ finite_difference rtol=2.0e-6 atol=2.0e-7
-        @test projected_force[mu][igen, site...] ≈ p[mu][igen, site...] rtol=1.0e-12 atol=1.0e-12
+        @test projected_force[mu][igen, site...] ≈
+              p[mu][igen, site...] rtol=1.0e-12 atol=1.0e-12
     end
 
     if NC == 2 && L == 1
+        site = only(sites)
         phi = similar(X)
         normal_operator = LDO.DdagD_Wilson_operator(D)
         mul!(phi, normal_operator, X)
@@ -214,7 +234,9 @@ end
         test_force(NC; L=1, all_generators=true)
         test_csw_zero_force(NC)
     end
-    test_force(2; L=2, all_generators=false)
+    for NC in (2, 3)
+        test_force(NC; L=2, all_generators=true)
+    end
 end
 
 end

--- a/test/wilson_clover.jl
+++ b/test/wilson_clover.jl
@@ -1,0 +1,220 @@
+module WilsonCloverTests
+
+using Gaugefields
+using LatticeDiracOperators
+using LinearAlgebra
+using Random
+using Test
+
+import Gaugefields: Initialize_4DGaugefields
+import LatticeDiracOperators.Dirac_operators: apply_γ5!
+
+const LDO = LatticeDiracOperators.Dirac_operators
+const KAPPA = 0.08
+const FORCE_EPSILON = 1.0e-6
+
+function make_gauge(NC; L=2, condition="hot", seed=2026071601)
+    Random.seed!(seed + NC + L)
+    return Initialize_4DGaugefields(NC, 0, L, L, L, L; condition=condition)
+end
+
+function make_spinor(U; seed=2026071602)
+    Random.seed!(seed + U[1].NC)
+    x = Initialize_pseudofermion_fields(U[1], "Wilson")
+    gauss_distribution_fermion!(x)
+    return x
+end
+
+function wilson_parameters(; csw=nothing)
+    parameters = Dict{String,Any}(
+        "Dirac_operator" => isnothing(csw) ? "Wilson" : "WilsonClover",
+        "κ" => KAPPA,
+        "faster version" => false,
+        "eps_CG" => 1.0e-12,
+        "MaxCGstep" => 10000,
+        "verbose_level" => 0,
+    )
+    if !isnothing(csw)
+        parameters["cSW"] = csw
+    end
+    return parameters
+end
+
+function apply_operator(D, x)
+    out = similar(x)
+    mul!(out, D, x)
+    return out
+end
+
+field_vector(x) = ComplexF64[x[i] for i = 1:length(x)]
+
+function relative_field_error(x, y)
+    xv = field_vector(x)
+    yv = field_vector(y)
+    return norm(xv - yv) / max(norm(yv), 1.0)
+end
+
+function perturb_link(U, mu, igen, site, epsilon)
+    Uwork = [similar(link) for link in U]
+    substitute_U!(Uwork, U)
+    tangent = initialize_TA_Gaugefields(U)
+    clear_U!(tangent)
+    tangent[mu][igen, site...] = 1.0
+    expU = similar(U[mu])
+    temp1 = similar(U[mu])
+    temp2 = similar(U[mu])
+    newlink = similar(U[mu])
+    exptU!(expU, epsilon, tangent[mu], [temp1, temp2])
+    mul!(newlink, expU, U[mu])
+    substitute_U!(Uwork[mu], newlink)
+    set_wing_U!(Uwork)
+    return Uwork
+end
+
+function fixed_xy_finite_difference(action, U, X, Y, mu, igen, site)
+    Uplus = perturb_link(U, mu, igen, site, FORCE_EPSILON)
+    Uminus = perturb_link(U, mu, igen, site, -FORCE_EPSILON)
+    DplusX = apply_operator(action.diracoperator(Uplus), X)
+    DminusX = apply_operator(action.diracoperator(Uminus), X)
+    return -2real((dot(Y, DplusX) - dot(Y, DminusX)) / (2FORCE_EPSILON))
+end
+
+function test_operator(NC)
+    U = make_gauge(NC)
+    x = make_spinor(U)
+    Dwilson = Dirac_operator(U, x, wilson_parameters())
+    Dzero = Dirac_operator(U, x, wilson_parameters(csw=0.0))
+    Dclover = Dirac_operator(U, x, wilson_parameters(csw=0.7))
+
+    @test relative_field_error(apply_operator(Dzero, x), apply_operator(Dwilson, x)) < 1.0e-12
+    @test relative_field_error(apply_operator(Dzero', x), apply_operator(Dwilson', x)) < 1.0e-12
+
+    Nwilson = DdagD_operator(U, x, wilson_parameters())
+    Nzero = DdagD_operator(U, x, wilson_parameters(csw=0.0))
+    @test relative_field_error(apply_operator(Nzero, x), apply_operator(Nwilson, x)) < 1.0e-12
+
+    y = make_spinor(U; seed=2026071603)
+    lhs = dot(y, apply_operator(Dclover, x))
+    rhs = dot(apply_operator(Dclover', y), x)
+    @test lhs ≈ rhs rtol=1.0e-12 atol=1.0e-12
+
+    gamma5_x = deepcopy(x)
+    apply_γ5!(gamma5_x)
+    gamma5_D_gamma5_x = apply_operator(Dclover, gamma5_x)
+    apply_γ5!(gamma5_D_gamma5_x)
+    @test relative_field_error(gamma5_D_gamma5_x, apply_operator(Dclover', x)) < 1.0e-12
+
+    maximum_antihermitian_error = 0.0
+    maximum_trace_error = 0.0
+    for ipair in axes(Dclover.cloverterm.Fmunu, 4)
+        for isite in axes(Dclover.cloverterm.Fmunu, 3)
+            F = Dclover.cloverterm.Fmunu[:, :, isite, ipair]
+            maximum_antihermitian_error = max(maximum_antihermitian_error, norm(F + F'))
+            maximum_trace_error = max(maximum_trace_error, abs(tr(F)))
+        end
+    end
+    @test norm(Dclover.cloverterm.Fmunu) > 1.0e-12
+    @test maximum_antihermitian_error < 1.0e-12
+    @test maximum_trace_error < 1.0e-12
+
+    Dquarter = Dirac_operator(U, x, wilson_parameters(csw=0.25))
+    Dhalf = Dirac_operator(U, x, wilson_parameters(csw=0.50))
+    y0 = field_vector(apply_operator(Dzero, x))
+    yquarter = field_vector(apply_operator(Dquarter, x))
+    yhalf = field_vector(apply_operator(Dhalf, x))
+    @test norm((yhalf - y0) - 2 .* (yquarter - y0)) / max(norm(yhalf - y0), 1.0) < 1.0e-12
+
+    Ucold = make_gauge(NC; condition="cold")
+    Dcold = Dirac_operator(Ucold, x, wilson_parameters(csw=1.0))
+    Wcold = Dirac_operator(Ucold, x, wilson_parameters())
+    @test norm(Dcold.cloverterm.Fmunu) < 1.0e-12
+    @test relative_field_error(apply_operator(Dcold, x), apply_operator(Wcold, x)) < 1.0e-12
+
+    parameters = wilson_parameters(csw=0.4)
+    Dirac_operator(U, x, parameters)
+    @test !haskey(parameters, "hasclover")
+end
+
+function test_force(NC; L=1, all_generators=true)
+    U = make_gauge(NC; L=L, seed=2026071610)
+    X = make_spinor(U; seed=2026071611)
+    D = Dirac_operator(U, X, wilson_parameters(csw=0.7))
+    action = FermiAction(D, Dict{String,Any}())
+
+    Y = similar(X)
+    p = initialize_TA_Gaugefields(U)
+    clear_U!(p)
+    LDO.calc_p_UdSfdU_fromX!(p, Y, action, U, X; coeff=1.0)
+
+    raw_force = [similar(link) for link in U]
+    clear_U!(raw_force)
+    Yraw = similar(X)
+    LDO.calc_UdSfdU_fromX!(raw_force, Yraw, action, U, X; coeff=1.0)
+    projected_force = initialize_TA_Gaugefields(U)
+    clear_U!(projected_force)
+    for mu in eachindex(U)
+        Traceless_antihermitian_add!(projected_force[mu], 1.0, raw_force[mu])
+    end
+
+    generators = LDO._sun_generator_matrices_for_clover_force(NC)
+    generator_indices = all_generators ? eachindex(generators) : 1:1
+    site = (1, 1, 1, 1)
+    mu = 1
+    for igen in generator_indices
+        finite_difference = fixed_xy_finite_difference(action, U, X, Y, mu, igen, site)
+        @test p[mu][igen, site...] ≈ finite_difference rtol=2.0e-6 atol=2.0e-7
+        @test projected_force[mu][igen, site...] ≈ p[mu][igen, site...] rtol=1.0e-12 atol=1.0e-12
+    end
+
+    if NC == 2 && L == 1
+        phi = similar(X)
+        normal_operator = LDO.DdagD_Wilson_operator(D)
+        mul!(phi, normal_operator, X)
+        solved_force = initialize_TA_Gaugefields(U)
+        clear_U!(solved_force)
+        calc_p_UdSfdU!(solved_force, action, U, phi, 1.0)
+        for direction in eachindex(U), igen in eachindex(generators)
+            @test solved_force[direction][igen, site...] ≈
+                  p[direction][igen, site...] rtol=2.0e-6 atol=2.0e-7
+        end
+    end
+end
+
+function test_csw_zero_force(NC)
+    U = make_gauge(NC; L=1, seed=2026071620)
+    X = make_spinor(U; seed=2026071621)
+    Dwilson = Dirac_operator(U, X, wilson_parameters())
+    Dzero = Dirac_operator(U, X, wilson_parameters(csw=0.0))
+    wilson_action = FermiAction(Dwilson, Dict{String,Any}())
+    zero_action = FermiAction(Dzero, Dict{String,Any}())
+    pwilson = initialize_TA_Gaugefields(U)
+    pzero = initialize_TA_Gaugefields(U)
+    clear_U!(pwilson)
+    clear_U!(pzero)
+    Ywilson = similar(X)
+    Yzero = similar(X)
+    LDO.calc_p_UdSfdU_fromX!(pwilson, Ywilson, wilson_action, U, X; coeff=1.0)
+    LDO.calc_p_UdSfdU_fromX!(pzero, Yzero, zero_action, U, X; coeff=1.0)
+    generators = LDO._sun_generator_matrices_for_clover_force(NC)
+    site = (1, 1, 1, 1)
+    for direction in eachindex(U), igen in eachindex(generators)
+        @test pzero[direction][igen, site...] ≈
+              pwilson[direction][igen, site...] rtol=1.0e-12 atol=1.0e-12
+    end
+end
+
+@testset "Wilson-clover operator" begin
+    for NC in (2, 3)
+        test_operator(NC)
+    end
+end
+
+@testset "Wilson-clover analytic force" begin
+    for NC in (2, 3)
+        test_force(NC; L=1, all_generators=true)
+        test_csw_zero_force(NC)
+    end
+    test_force(2; L=2, all_generators=false)
+end
+
+end


### PR DESCRIPTION
## Summary

- replace the incomplete Wilson-clover local term with a traceless anti-Hermitian four-leaf field-strength implementation
- add the analytic Clover force to both momentum-basis and raw-matrix force APIs
- make the named `WilsonClover` operator and `DdagD_operator` path consistent without mutating caller parameters
- add focused SU(2)/SU(3) operator and force regression tests

## Validation

- Wilson-clover operator tests: 24/24 passed
- analytic force and force regression tests: 254/254 passed
- the permanent tests cover `cSW=0` Wilson regression, adjointness, gamma5 hermiticity, `cSW` linearity, every SU(2)/SU(3) generator, raw/momentum force agreement, and the solve-and-force entry point used by HMC
- `L=2` force coverage includes SU(2), SU(3), all 4 link directions, all generators, and 2 sites on a deterministic nontrivial gauge field
- an external 264-component scan at `cSW=0.3,0.7,1.5` passed the predeclared finite-difference tolerance; the largest raw/momentum projection difference was `3.33e-16`
- the same 264 components also passed on a nondegenerate `L=3` lattice, where forward and backward periodic neighbors do not coincide; at the epsilon-scan optimum `1e-4`, the largest absolute error was `1.32e-8`, the largest mixed residual was `0.0484`, and the largest raw/momentum projection difference was `5.55e-16`
- the generic `N>3` generator branch passed another 360 components for SU(4), `L=3`, and the same three `cSW` values; the largest mixed residual was `0.0573`
- a public-dependency-only SU(3) molecular-dynamics scan gave log-log slopes `1.9896`, `1.9894`, and `1.9890` for `cSW=0,0.7,1.5`, consistent with second-order leapfrog scaling
- tests were run on `mini4` with Julia 1.11.5, Gaugefields 0.7.2, LatticeMatrices 0.3.13, Wilsonloop 0.1.5, and registered public dependencies

Focused command:

```sh
julia --project=. test/wilson_clover.jl
```

The complete upstream test suite is left to CI. No HMC chain was run on the MacBook Air.

## Known CI blocker

The Documentation workflow currently fails before loading this change because the tracked root `Manifest.toml` points `LatticeMatrices` to `/Users/yuki/git/LatticeMatrices.jl/`. The same failure is present on the `v0.6.3` master run, so the manifest/CI repair should remain a separate change.
