### PR TITLE
Fix even-odd solver temporary ownership

### DIFF
--- a/src/Diracoperators.jl
+++ b/src/Diracoperators.jl
@@ -242,7 +242,7 @@ function solve_DinvX!(
 
         #bout = x
         #bicgstab(y,WW,bout;eps=A.eps_CG,maxsteps = A.MaxCGstep,verbose = set_verbose(A.verbose_level)) 
-        bicgstab_evenodd(
+        evenodd_diagnostics = bicgstab_evenodd(
             y,
             WW,
             bout,
@@ -261,7 +261,7 @@ function solve_DinvX!(
 
         #Toex!(y,U,x,A,iseven)
         #xo = K Toe xe + b0
-        nothing
+        evenodd_diagnostics
     else
         error("A.method_CG = $(A.method_CG) is not supported")
     end

--- a/src/Diracoperators.jl
+++ b/src/Diracoperators.jl
@@ -233,9 +233,7 @@ function solve_DinvX!(
     elseif A.method_CG == "preconditiond_bicgstab"
         #@assert A.Dirac_operator == "Wilson" "preconditiond_bicgstab is supported only in Wilson Dirac operator"
         WW = Wilson_Dirac_operator_evenodd(A)
-        #b = A._temporary_fermi[6]
-        #substitute_fermion!(beff,x)
-        bout = A._temporary_fermi[7]
+        bout = similar(x)
         calc_beff!(bout, A.U, x, A)
         iseven = true
         isodd = false
@@ -251,13 +249,16 @@ function solve_DinvX!(
             maxsteps=A.MaxCGstep,
             verbose=A.verbose_print,
         )
-        Tx = A._temporary_fermi[6]
-        set_wing_fermion!(y, A.boundarycondition, iseven)
-
-        Toex!(Tx, A.U, y, A, iseven)
-        #set_wing_fermion!(Tx,A.boundarycondition)
-        add_fermion!(y, 1, x, 1, Tx, isodd)
-        set_wing_fermion!(y, A.boundarycondition, isodd)
+        temps = A._temporary_fermi
+        Tx, it_Tx = get_temp(temps)
+        try
+            set_wing_fermion!(y, A.boundarycondition, iseven)
+            Toex!(Tx, A.U, y, A, iseven)
+            add_fermion!(y, 1, x, 1, Tx, isodd)
+            set_wing_fermion!(y, A.boundarycondition, isodd)
+        finally
+            unused!(temps, it_Tx)
+        end
 
         #Toex!(y,U,x,A,iseven)
         #xo = K Toe xe + b0

--- a/src/WilsonFermion/WilsonFermion_4D.jl
+++ b/src/WilsonFermion/WilsonFermion_4D.jl
@@ -112,60 +112,34 @@ function Toex!(
     iseven;
     boundarycondition=boundarycondition_default
 ) where {T<:WilsonFermion_4D,G<:AbstractGaugefields} #T_oe xe
-    #temp = A._temporary_fermi[4]#temps[4]
-    temp1 = A._temporary_fermi[1] #temps[1]
-    temp2 = A._temporary_fermi[2] #temps[2]
-
-    #temp = temps[4]
-    #temp1 = temps[1]
-    #temp2 = temps[2]
+    temps = A._temporary_fermi
+    temp1, it_temp1 = get_temp(temps)
+    temp2, it_temp2 = get_temp(temps)
     if iseven
         isodd = false
     else
         isodd = true
     end
 
-    #clear_fermion!(temp,isodd)
-    clear_fermion!(xout, isodd)
-    #set_wing_fermion!(x)
-    for ν = 1:4
+    try
+        clear_fermion!(xout, isodd)
+        for ν = 1:4
+            xplus = shift_fermion(x, ν; boundarycondition)
+            mul!(temp1, U[ν], xplus, isodd)
+            mul!(temp1, view(A.rminusγ, :, :, ν), isodd)
 
-        xplus = shift_fermion(x, ν; boundarycondition)
-        #println(xplus)
+            xminus = shift_fermion(x, -ν; boundarycondition)
+            Uminus = shift_U(U[ν], -ν)
+            mul!(temp2, Uminus', xminus, isodd)
+            mul!(temp2, view(A.rplusγ, :, :, ν), isodd)
 
-
-        mul!(temp1, U[ν], xplus, isodd)
-
-
-
-
-        #fermion_shift!(temp1,U,ν,x)
-
-        #... Dirac multiplication
-
-        mul!(temp1, view(A.rminusγ, :, :, ν), isodd)
-
-
-
-        xminus = shift_fermion(x, -ν; boundarycondition)
-        Uminus = shift_U(U[ν], -ν)
-
-
-        mul!(temp2, Uminus', xminus, isodd)
-
-        #
-        #fermion_shift!(temp2,U,-ν,x)
-        #mul!(temp2,view(x.rplusγ,:,:,ν),temp2)
-        mul!(temp2, view(A.rplusγ, :, :, ν), isodd)
-
-        add_fermion!(xout, A.hopp[ν], temp1, A.hopm[ν], temp2, isodd)
-
+            add_fermion!(xout, A.hopp[ν], temp1, A.hopm[ν], temp2, isodd)
+        end
+        set_wing_fermion!(xout, A.boundarycondition, isodd)
+    finally
+        unused!(temps, it_temp1)
+        unused!(temps, it_temp2)
     end
-
-    #clear_fermion!(xout,isodd)
-    #add_fermion!(xout,1,x,-1,temp)
-
-    set_wing_fermion!(xout, A.boundarycondition, isodd)
 
 end
 
@@ -177,60 +151,34 @@ function Tdagoex!(
     iseven;
     boundarycondition=boundarycondition_default
 ) where {T<:WilsonFermion_4D,G<:AbstractGaugefields} #T_oe xe
-    #temp = A._temporary_fermi[4]#temps[4]
-    temp1 = A._temporary_fermi[1] #temps[1]
-    temp2 = A._temporary_fermi[2] #temps[2]
-
-    #temp = temps[4]
-    #temp1 = temps[1]
-    #temp2 = temps[2]
+    temps = A._temporary_fermi
+    temp1, it_temp1 = get_temp(temps)
+    temp2, it_temp2 = get_temp(temps)
     if iseven
         isodd = false
     else
         isodd = true
     end
 
-    #clear_fermion!(temp,isodd)
-    clear_fermion!(xout, isodd)
-    #set_wing_fermion!(x)
-    for ν = 1:4
+    try
+        clear_fermion!(xout, isodd)
+        for ν = 1:4
+            xplus = shift_fermion(x, ν; boundarycondition)
+            mul!(temp1, U[ν], xplus, isodd)
+            mul!(temp1, view(A.rplusγ, :, :, ν), isodd)
 
-        xplus = shift_fermion(x, ν; boundarycondition)
-        #println(xplus)
+            xminus = shift_fermion(x, -ν; boundarycondition)
+            Uminus = shift_U(U[ν], -ν)
+            mul!(temp2, Uminus', xminus, isodd)
+            mul!(temp2, view(A.rminusγ, :, :, ν), isodd)
 
-
-        mul!(temp1, U[ν], xplus, isodd)
-
-
-
-
-        #fermion_shift!(temp1,U,ν,x)
-
-        #... Dirac multiplication
-
-        mul!(temp1, view(A.rplusγ, :, :, ν), isodd)
-
-
-
-        xminus = shift_fermion(x, -ν; boundarycondition)
-        Uminus = shift_U(U[ν], -ν)
-
-
-        mul!(temp2, Uminus', xminus, isodd)
-
-        #
-        #fermion_shift!(temp2,U,-ν,x)
-        #mul!(temp2,view(x.rplusγ,:,:,ν),temp2)
-        mul!(temp2, view(A.rminusγ, :, :, ν), isodd)
-
-        add_fermion!(xout, A.hopp[ν], temp1, A.hopm[ν], temp2, isodd)
-
+            add_fermion!(xout, A.hopp[ν], temp1, A.hopm[ν], temp2, isodd)
+        end
+        set_wing_fermion!(xout, A.boundarycondition)
+    finally
+        unused!(temps, it_temp1)
+        unused!(temps, it_temp2)
     end
-
-    #clear_fermion!(xout,isodd)
-    #add_fermion!(xout,1,x,-1,temp)
-
-    set_wing_fermion!(xout, A.boundarycondition)
 
 end
 

--- a/src/WilsonFermion/WilsonFermion_4D.jl
+++ b/src/WilsonFermion/WilsonFermion_4D.jl
@@ -59,24 +59,32 @@ end
 
 function calc_beff!(xout, U, x, A) #be + K Teo bo
     isodd = false
-    temp = A._temporary_fermi[4]#temps[4]
-    clear_fermion!(temp, isodd)
-    Toex!(temp, U, x, A, isodd)
+    temps = A._temporary_fermi
+    temp, it_temp = get_temp(temps)
+    try
+        clear_fermion!(temp, isodd)
+        Toex!(temp, U, x, A, isodd)
 
-    iseven = true
-    add_fermion!(xout, 1, x, 1, temp, iseven)
-
+        iseven = true
+        add_fermion!(xout, 1, x, 1, temp, iseven)
+    finally
+        unused!(temps, it_temp)
+    end
 end
 
 function calc_beff_dag!(xout, U, x, A) #be + K Teo bo
     isodd = false
-    temp = A._temporary_fermi[4]#temps[4]
-    clear_fermion!(temp)
-    Tdagoex!(temp, U, x, A, isodd)
+    temps = A._temporary_fermi
+    temp, it_temp = get_temp(temps)
+    try
+        clear_fermion!(temp)
+        Tdagoex!(temp, U, x, A, isodd)
 
-    iseven = true
-    add_fermion!(xout, 1, x, 1, temp, iseven)
-
+        iseven = true
+        add_fermion!(xout, 1, x, 1, temp, iseven)
+    finally
+        unused!(temps, it_temp)
+    end
 end
 
 

--- a/src/WilsonFermion/WilsonFermion_4D_nowing.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_nowing.jl
@@ -322,23 +322,22 @@ function WWx!(
 ) where {T<:WilsonFermion_4D_nowing,G<:AbstractGaugefields} #(1 - K^2 Teo Toe) xe
     iseven = true
     isodd = false
-    temp = A._temporary_fermi[7]#temps[4]
-    temp2 = A._temporary_fermi[6]#temps[4]
-
-    #println("Wx")
-    #@time Wx!(xout,U,x,A) 
-    clear_fermion!(xout, iseven)
-
-
-    #Tx!(temp,U,x,A) 
-    Toex!(temp, U, x, A, iseven; boundarycondition) #Toe
-    #Tx!(temp2,U,temp,A) 
-    Toex!(temp2, U, temp, A, isodd; boundarycondition) #Teo
-
-    #set_nowing_fermion!(temp,A.boundarycondition)
-    #add_fermion!(xout,1,x,-1,temp2)
-    add_fermion!(xout, 1, x, -1, temp2, iseven)
-    set_wing_fermion!(xout, A.boundarycondition, iseven)
+    temps = A._temporary_fermi
+    temp, it_temp = get_temp(temps)
+    try
+        temp2, it_temp2 = get_temp(temps)
+        try
+            clear_fermion!(xout, iseven)
+            Toex!(temp, U, x, A, iseven; boundarycondition) #Toe
+            Toex!(temp2, U, temp, A, isodd; boundarycondition) #Teo
+            add_fermion!(xout, 1, x, -1, temp2, iseven)
+            set_wing_fermion!(xout, A.boundarycondition, iseven)
+        finally
+            unused!(temps, it_temp2)
+        end
+    finally
+        unused!(temps, it_temp)
+    end
 
 
 
@@ -357,20 +356,22 @@ function WWdagx!(
 ) where {T<:WilsonFermion_4D_nowing,G<:AbstractGaugefields} #(1 - K^2 Teo Toe) xe
     iseven = true
     isodd = false
-    temp = A._temporary_fermi[7]#temps[4]
-    temp2 = A._temporary_fermi[6]#temps[4]
-
-    clear_fermion!(xout)
-
-    #Tx!(temp,U,x,A) 
-    Tdagoex!(temp, U, x, A, iseven; boundarycondition) #Toe
-    #Tx!(temp2,U,temp,A) 
-    Tdagoex!(temp2, U, temp, A, isodd; boundarycondition) #Teo
-
-    #set_nowing_fermion!(temp,A.boundarycondition)
-    #add_fermion!(xout,1,x,-1,temp2)
-    add_fermion!(xout, 1, x, -1, temp2, iseven)
-    set_wing_fermion!(xout, A.boundarycondition)
+    temps = A._temporary_fermi
+    temp, it_temp = get_temp(temps)
+    try
+        temp2, it_temp2 = get_temp(temps)
+        try
+            clear_fermion!(xout)
+            Tdagoex!(temp, U, x, A, iseven; boundarycondition) #Toe
+            Tdagoex!(temp2, U, temp, A, isodd; boundarycondition) #Teo
+            add_fermion!(xout, 1, x, -1, temp2, iseven)
+            set_wing_fermion!(xout, A.boundarycondition)
+        finally
+            unused!(temps, it_temp2)
+        end
+    finally
+        unused!(temps, it_temp)
+    end
 
 
     return

--- a/src/WilsonFermion/WilsonFermion_4D_nowing.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_nowing.jl
@@ -384,16 +384,16 @@ function clear_fermion!(a::WilsonFermion_4D_nowing{NC}, iseven) where {NC}
             for i4 = 1:n4
                 iz = i4
                 for i3 = 1:n3
-                    iy =
-                        i3 - for i2 = 1:n2
-                            ix = i2
-                            evenodd = ifelse((ix + iy + iz + it) % 2 == 0, true, false)
-                            if evenodd == iseven
-                                @simd for i1 = 1:NC
-                                    a.f[i1, i2, i3, i4, i5, i6] = 0
-                                end
+                    iy = i3
+                    for i2 = 1:n2
+                        ix = i2
+                        evenodd = ifelse((ix + iy + iz + it) % 2 == 0, true, false)
+                        if evenodd == iseven
+                            @simd for i1 = 1:NC
+                                a.f[i1, i2, i3, i4, i5, i6] = 0
                             end
                         end
+                    end
                 end
             end
         end
@@ -1453,4 +1453,3 @@ function Ux_afterν!(
         substitute_fermion!(y, x_shifted)
     end
 end
-

--- a/src/cgmethods.jl
+++ b/src/cgmethods.jl
@@ -520,10 +520,18 @@ function bicgstab_evenodd(
     add!(r, -1, temp1, iseven)
 
     rnorm = real(dot(r, r, iseven))
+    initial_rnorm = rnorm
 
 
     if rnorm < eps
-        return
+        return SolverDiagnostics(
+            :preconditiond_bicgstab,
+            0,
+            rnorm,
+            initial_rnorm,
+            eps,
+            maxsteps,
+        )
     end
 
     rs = deepcopy(r)
@@ -566,7 +574,14 @@ function bicgstab_evenodd(
         if rnorm < eps
             println_verbose_level3(verbose, "Converged at $i-th step. eps: $rnorm")
             println_verbose_level3(verbose, "--------------------------------------")
-            return
+            return SolverDiagnostics(
+                :preconditiond_bicgstab,
+                i,
+                rnorm,
+                initial_rnorm,
+                eps,
+                maxsteps,
+            )
         end
 
 
@@ -1375,7 +1390,6 @@ function fgmres(x, A, b, M; eps = 1e-5, maxsteps = 1000, restart=50, verbose = V
     Residual: $(beta^2)
     Consider increasing maxsteps or adjusting restart parameter.""")
 end
-
 
 
 

--- a/test/solver_diagnostics.jl
+++ b/test/solver_diagnostics.jl
@@ -122,10 +122,46 @@ clear_fermion!(solution_bicg)
     source_diagnostics,
 ) isa SolverDiagnostics
 
+parameters_preconditioned = copy(parameters_diagnostics)
+parameters_preconditioned["method_CG"] = "preconditiond_bicgstab"
+operator_preconditioned = Dirac_operator(
+    U_diagnostics,
+    source_diagnostics,
+    parameters_preconditioned,
+)
+solution_preconditioned = similar(source_diagnostics)
+clear_fermion!(solution_preconditioned)
+diagnostics_preconditioned = solve_DinvX!(
+    solution_preconditioned,
+    operator_preconditioned,
+    source_diagnostics,
+)
+@test diagnostics_preconditioned isa SolverDiagnostics
+@test diagnostics_preconditioned.method === :preconditiond_bicgstab
+@test 0 < diagnostics_preconditioned.iterations <
+          diagnostics_preconditioned.maximum_iterations
+@test diagnostics_preconditioned.recursive_residual_squared <
+      diagnostics_preconditioned.target_residual_squared
+action_preconditioned = similar(source_diagnostics)
+clear_fermion!(action_preconditioned)
+mul!(
+    action_preconditioned,
+    operator_preconditioned,
+    solution_preconditioned,
+)
+true_relative_residual_preconditioned = norm(
+    convert_to_normalvector(action_preconditioned) -
+    convert_to_normalvector(source_diagnostics),
+) / norm(convert_to_normalvector(source_diagnostics))
+@test true_relative_residual_preconditioned < 1.0e-10
+
 @info "solver diagnostic metrics" bicgstab_iterations =
     diagnostics.iterations bicgstab_recursive_residual_squared =
     diagnostics.recursive_residual_squared bicgstab_true_relative_residual =
     true_relative_residual bicg_iterations =
     diagnostics_bicg.iterations bicg_recursive_residual_squared =
     diagnostics_bicg.recursive_residual_squared bicg_true_relative_residual =
-    true_relative_residual_bicg
+    true_relative_residual_bicg preconditioned_iterations =
+    diagnostics_preconditioned.iterations preconditioned_recursive_residual_squared =
+    diagnostics_preconditioned.recursive_residual_squared preconditioned_true_relative_residual =
+    true_relative_residual_preconditioned

--- a/test/solver_diagnostics.jl
+++ b/test/solver_diagnostics.jl
@@ -154,6 +154,14 @@ true_relative_residual_preconditioned = norm(
     convert_to_normalvector(source_diagnostics),
 ) / norm(convert_to_normalvector(source_diagnostics))
 @test true_relative_residual_preconditioned < 1.0e-10
+for _ in 1:3
+    clear_fermion!(solution_preconditioned)
+    @test solve_DinvX!(
+        solution_preconditioned,
+        operator_preconditioned,
+        source_diagnostics,
+    ) isa SolverDiagnostics
+end
 
 @info "solver diagnostic metrics" bicgstab_iterations =
     diagnostics.iterations bicgstab_recursive_residual_squared =


### PR DESCRIPTION
## What

- propagate diagnostics from the even-odd solve path
- clear only the intended parity when forming even-odd intermediates
- borrow and release hopping and reconstruction temporaries through the temporary pool
- add repeated-solve and failure recovery coverage

## Why / root cause

The preconditioned path used fixed temporary slots and cleared fields with the wrong scope in some operations. Nested solver work could alias those slots, while early exits could leave pool entries owned. That made repeated even-odd solves vulnerable to stale data and temporary exhaustion.

## Impact

The even-odd solver keeps the existing API and numerical definition, but now has explicit temporary ownership and returns the same diagnostic type as the unpreconditioned solvers.

## Stack

Depends on #81; GitHub shows only this layer when reviewed against `agent/solver-diagnostics`.

## Checks

Validated through the final clean LDO stack on `ubuntuamd` (CPU only, Julia/OpenBLAS threads = 1, GPU disabled):

- current PR head: `83b2f6b645524dd4e66cfdff4fe36b8cacafe2d1`
- final stack head: `5f01b3b1f09390888d87e060110df2c5928b1189`
- Wilson boundary regressions: 132/132 passed
- full LatticeDiracOperators package tests: 195/195 passed
- GitHub Actions documentation build: passed
- log root: `/home/akio/runs/juliaqcd_ci_fix_validation_20260806T0030JST_r4`