### PR TITLE
Handle BiCGStab convergence and shadow-residual restarts

### DIFF
--- a/src/cgmethods.jl
+++ b/src/cgmethods.jl
@@ -213,6 +213,23 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
             #s = r - α*A*p
             add!(0, s, 1, r)
             add!(s, -α, Ap)
+            snorm = real(s ⋅ s)
+            if snorm < eps
+                add!(x, α, p)
+                println_verbose_level3(
+                    verbose,
+                    "Converged at $i-th step. eps: $snorm",
+                )
+                println_verbose_level3(verbose, "--------------------------------------")
+                return SolverDiagnostics(
+                    :bicgstab,
+                    i,
+                    snorm,
+                    initial_rnorm,
+                    eps,
+                    maxsteps,
+                )
+            end
             mul!(t, A, s)
             d1 = dot(t, s)
             d2 = dot(t, t)
@@ -549,6 +566,20 @@ function bicgstab_evenodd(
         #s = r - α*A*p
         add!(0, s, 1, r, iseven)
         add!(s, -α, Ap, iseven)
+        snorm = real(dot(s, s, iseven))
+        if snorm < eps
+            add!(x, α, p, iseven)
+            println_verbose_level3(verbose, "Converged at $i-th step. eps: $snorm")
+            println_verbose_level3(verbose, "--------------------------------------")
+            return SolverDiagnostics(
+                :preconditiond_bicgstab,
+                i,
+                snorm,
+                initial_rnorm,
+                eps,
+                maxsteps,
+            )
+        end
         mul!(t, A, s)
         d1 = dot(t, s, iseven)
         d2 = dot(t, t, iseven)
@@ -1390,7 +1421,6 @@ function fgmres(x, A, b, M; eps = 1e-5, maxsteps = 1000, restart=50, verbose = V
     Residual: $(beta^2)
     Consider increasing maxsteps or adjusting restart parameter.""")
 end
-
 
 
 

--- a/src/cgmethods.jl
+++ b/src/cgmethods.jl
@@ -207,6 +207,16 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
 
         for i = 1:maxsteps
             c1 = dot(rs, r)
+            rho_scale = sqrt(real(rs ⋅ rs) * real(r ⋅ r))
+            if abs(c1) <= Base.eps(Float64) * rho_scale
+                substitute_fermion!(rs, r)
+                substitute_fermion!(p, r)
+                c1 = rs ⋅ r
+                println_verbose_level3(
+                    verbose,
+                    "Restarted BiCGStab shadow residual at $i-th step",
+                )
+            end
             mul!(Ap, A, p)
             c2 = dot(rs, Ap)
             α = c1 / c2
@@ -243,12 +253,6 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
             add!(x, ω, s)
             add!(x, α, p)
 
-            β = (dot(rs, r) / c1) * (α / ω)
-
-            #p = r + β*(1-ωA)*p
-            add!(β, p, 1, r)
-            add!(p, -ω * β, Ap)
-
             rnorm = real(r ⋅ r)
             println_verbose_level3(verbose, "$i-th eps: $rnorm")
 
@@ -267,6 +271,12 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
                     maxsteps,
                 )
             end
+
+            β = (dot(rs, r) / c1) * (α / ω)
+
+            #p = r + β*(1-ωA)*p
+            add!(β, p, 1, r)
+            add!(p, -ω * β, Ap)
         end
 
         error("""
@@ -560,6 +570,17 @@ function bicgstab_evenodd(
 
     for i = 1:maxsteps
         c1 = dot(rs, r, iseven)
+        rho_scale =
+            sqrt(real(dot(rs, rs, iseven)) * real(dot(r, r, iseven)))
+        if abs(c1) <= Base.eps(Float64) * rho_scale
+            add!(0, rs, 1, r, iseven)
+            add!(0, p, 1, r, iseven)
+            c1 = dot(rs, r, iseven)
+            println_verbose_level3(
+                verbose,
+                "Restarted BiCGStab shadow residual at $i-th step",
+            )
+        end
         mul!(Ap, A, p)
         c2 = dot(rs, Ap, iseven)
         println_verbose_level3(verbose, "$i-th c1: $c1 c2: $c2")
@@ -595,13 +616,6 @@ function bicgstab_evenodd(
         add!(x, ω, s, iseven)
         add!(x, α, p, iseven)
 
-        β = (dot(rs, r, iseven) / c1) * (α / ω)
-        println_verbose_level3(verbose, "$i-th alpha: $α omega: $ω beta: $β")
-
-        #p = r + β*(1-ωA)*p
-        add!(β, p, 1, r, iseven)
-        add!(p, -ω * β, Ap, iseven)
-
         rnorm = real(dot(r, r, iseven))
         println_verbose_level3(verbose, "$i-th eps: $rnorm")
 
@@ -617,6 +631,13 @@ function bicgstab_evenodd(
                 maxsteps,
             )
         end
+
+        β = (dot(rs, r, iseven) / c1) * (α / ω)
+        println_verbose_level3(verbose, "$i-th alpha: $α omega: $ω beta: $β")
+
+        #p = r + β*(1-ωA)*p
+        add!(β, p, 1, r, iseven)
+        add!(p, -ω * β, Ap, iseven)
 
 
 
@@ -1424,6 +1445,5 @@ function fgmres(x, A, b, M; eps = 1e-5, maxsteps = 1000, restart=50, verbose = V
     Residual: $(beta^2)
     Consider increasing maxsteps or adjusting restart parameter.""")
 end
-
 
 

--- a/src/cgmethods.jl
+++ b/src/cgmethods.jl
@@ -562,6 +562,7 @@ function bicgstab_evenodd(
         c1 = dot(rs, r, iseven)
         mul!(Ap, A, p)
         c2 = dot(rs, Ap, iseven)
+        println_verbose_level3(verbose, "$i-th c1: $c1 c2: $c2")
         α = c1 / c2
         #s = r - α*A*p
         add!(0, s, 1, r, iseven)
@@ -583,6 +584,7 @@ function bicgstab_evenodd(
         mul!(t, A, s)
         d1 = dot(t, s, iseven)
         d2 = dot(t, t, iseven)
+        println_verbose_level3(verbose, "$i-th snorm: $snorm d1: $d1 d2: $d2")
         ω = d1 / d2
 
         #r = (1-ω A)s
@@ -594,6 +596,7 @@ function bicgstab_evenodd(
         add!(x, α, p, iseven)
 
         β = (dot(rs, r, iseven) / c1) * (α / ω)
+        println_verbose_level3(verbose, "$i-th alpha: $α omega: $ω beta: $β")
 
         #p = r + β*(1-ωA)*p
         add!(β, p, 1, r, iseven)
@@ -1421,7 +1424,6 @@ function fgmres(x, A, b, M; eps = 1e-5, maxsteps = 1000, restart=50, verbose = V
     Residual: $(beta^2)
     Consider increasing maxsteps or adjusting restart parameter.""")
 end
-
 
 
 

--- a/src/cgmethods.jl
+++ b/src/cgmethods.jl
@@ -13,7 +13,9 @@ Diagnostics returned by a successful iterative solve.
 
 `recursive_residual_squared` is the residual maintained by the algorithm.  A
 caller that needs a convergence gate should independently recompute the true
-residual from the returned solution.
+residual from the returned solution.  `restart_count` records shadow-residual
+restarts, and `convergence_branch` is one of `:initial_residual`,
+`:intermediate_residual`, or `:updated_residual`.
 """
 struct SolverDiagnostics
     method::Symbol
@@ -22,6 +24,8 @@ struct SolverDiagnostics
     initial_residual_squared::Float64
     target_residual_squared::Float64
     maximum_iterations::Int
+    restart_count::Int
+    convergence_branch::Symbol
 end
 
 
@@ -86,6 +90,8 @@ function bicg(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #Ax=b
                 initial_rnorm,
                 eps,
                 maxsteps,
+                0,
+                :initial_residual,
             )
         end
         #println(rnorm)
@@ -119,6 +125,8 @@ function bicg(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #Ax=b
                     initial_rnorm,
                     eps,
                     maxsteps,
+                    0,
+                    :updated_residual,
                 )
             end
 
@@ -202,9 +210,12 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
                 initial_rnorm,
                 eps,
                 maxsteps,
+                0,
+                :initial_residual,
             )
         end
 
+        restart_count = 0
         for i = 1:maxsteps
             c1 = dot(rs, r)
             rho_scale = sqrt(real(rs ⋅ rs) * real(r ⋅ r))
@@ -212,6 +223,7 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
                 substitute_fermion!(rs, r)
                 substitute_fermion!(p, r)
                 c1 = rs ⋅ r
+                restart_count += 1
                 println_verbose_level3(
                     verbose,
                     "Restarted BiCGStab shadow residual at $i-th step",
@@ -238,6 +250,8 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
                     initial_rnorm,
                     eps,
                     maxsteps,
+                    restart_count,
+                    :intermediate_residual,
                 )
             end
             mul!(t, A, s)
@@ -269,6 +283,8 @@ function bicgstab(x, A, b; eps=1e-10, maxsteps=1000, verbose=Verbose_print(2)) #
                     initial_rnorm,
                     eps,
                     maxsteps,
+                    restart_count,
+                    :updated_residual,
                 )
             end
 
@@ -558,6 +574,8 @@ function bicgstab_evenodd(
             initial_rnorm,
             eps,
             maxsteps,
+            0,
+            :initial_residual,
         )
     end
 
@@ -568,6 +586,7 @@ function bicgstab_evenodd(
     t = similar(r)
 
 
+    restart_count = 0
     for i = 1:maxsteps
         c1 = dot(rs, r, iseven)
         rho_scale =
@@ -576,6 +595,7 @@ function bicgstab_evenodd(
             add!(0, rs, 1, r, iseven)
             add!(0, p, 1, r, iseven)
             c1 = dot(rs, r, iseven)
+            restart_count += 1
             println_verbose_level3(
                 verbose,
                 "Restarted BiCGStab shadow residual at $i-th step",
@@ -600,6 +620,8 @@ function bicgstab_evenodd(
                 initial_rnorm,
                 eps,
                 maxsteps,
+                restart_count,
+                :intermediate_residual,
             )
         end
         mul!(t, A, s)
@@ -629,6 +651,8 @@ function bicgstab_evenodd(
                 initial_rnorm,
                 eps,
                 maxsteps,
+                restart_count,
+                :updated_residual,
             )
         end
 
@@ -1445,5 +1469,4 @@ function fgmres(x, A, b, M; eps = 1e-5, maxsteps = 1000, restart=50, verbose = V
     Residual: $(beta^2)
     Consider increasing maxsteps or adjusting restart parameter.""")
 end
-
 

--- a/test/solver_diagnostics.jl
+++ b/test/solver_diagnostics.jl
@@ -41,6 +41,9 @@ diagnostics = solve_DinvX!(
 @test diagnostics.recursive_residual_squared <
       diagnostics.target_residual_squared
 @test diagnostics.target_residual_squared == 1.0e-20
+@test diagnostics.restart_count >= 0
+@test diagnostics.convergence_branch in
+      (:intermediate_residual, :updated_residual)
 
 action_diagnostics = similar(source_diagnostics)
 clear_fermion!(action_diagnostics)
@@ -62,6 +65,8 @@ for _ in 1:3
         solve_DinvX!(zero_solution, operator_diagnostics, zero_source)
     @test zero_diagnostics.iterations == 0
     @test zero_diagnostics.recursive_residual_squared == 0
+    @test zero_diagnostics.restart_count == 0
+    @test zero_diagnostics.convergence_branch === :initial_residual
 end
 
 failed_solution = similar(source_diagnostics)
@@ -96,6 +101,8 @@ diagnostics_bicg =
 @test 0 < diagnostics_bicg.iterations < diagnostics_bicg.maximum_iterations
 @test diagnostics_bicg.recursive_residual_squared <
       diagnostics_bicg.target_residual_squared
+@test diagnostics_bicg.restart_count == 0
+@test diagnostics_bicg.convergence_branch === :updated_residual
 action_bicg = similar(source_diagnostics)
 clear_fermion!(action_bicg)
 mul!(action_bicg, operator_bicg, solution_bicg)
@@ -142,6 +149,9 @@ diagnostics_preconditioned = solve_DinvX!(
           diagnostics_preconditioned.maximum_iterations
 @test diagnostics_preconditioned.recursive_residual_squared <
       diagnostics_preconditioned.target_residual_squared
+@test diagnostics_preconditioned.restart_count >= 0
+@test diagnostics_preconditioned.convergence_branch in
+      (:intermediate_residual, :updated_residual)
 action_preconditioned = similar(source_diagnostics)
 clear_fermion!(action_preconditioned)
 mul!(


### PR DESCRIPTION
## What

- accept convergence at the intermediate BiCGStab residual before computing omega
- restart safely when the shadow-residual denominator breaks down
- record restart counts and the convergence branch in `SolverDiagnostics`
- retain breakdown scalars in even-odd failure messages
- cover the new outcome fields in regression tests

## Why / root cause

BiCGStab could reach tolerance at its intermediate residual and still continue into the omega update, where a zero denominator was reported as failure. Separately, a vanishing shadow-residual product was treated as terminal even when a safe residual restart was available.

## Impact

Legitimate convergence is no longer misclassified as breakdown, and recoverable shadow-residual breakdowns can restart with auditable diagnostics.

## Stack

Depends on `agent/evenodd-solver-ownership`.

## Checks

Validated through the final clean LDO stack on `ubuntuamd` (CPU only, Julia/OpenBLAS threads = 1, GPU disabled):

- exact current head: `275ea6ef666adc6254abc71488015c0c83489f09`
- final stack head: `5f01b3b1f09390888d87e060110df2c5928b1189`
- Wilson boundary regressions: 132/132 passed
- full LatticeDiracOperators package tests: 195/195 passed
- GitHub Actions documentation build: passed
- log root: `/home/akio/runs/juliaqcd_ci_fix_validation_20260806T0030JST_r4`