### PR TITLE
Honor Wilson boundary conditions on non-wing and non-cubic paths

### DIFF
--- a/src/AbstractFermions_2D.jl
+++ b/src/AbstractFermions_2D.jl
@@ -217,7 +217,11 @@ end
 
 
 #lattice shift
-function shift_fermion(F::AbstractFermionfields_2D{NC}, ν::T) where {T<:Integer,NC}
+function shift_fermion(
+    F::AbstractFermionfields_2D{NC},
+    ν::T;
+    boundarycondition=nothing,
+) where {T<:Integer,NC}
     if ν == 1
         shift = (1, 0)
     elseif ν == 2

--- a/src/AbstractFermions_4D.jl
+++ b/src/AbstractFermions_4D.jl
@@ -323,7 +323,11 @@ end
 
 
 #lattice shift
-function shift_fermion(F::AbstractFermionfields_4D{NC}, ν::T) where {T<:Integer,NC}
+function shift_fermion(
+    F::AbstractFermionfields_4D{NC},
+    ν::T;
+    boundarycondition=nothing,
+) where {T<:Integer,NC}
     if ν == 1
         shift = (1, 0, 0, 0)
     elseif ν == 2

--- a/src/WilsonFermion/WilsonFermion.jl
+++ b/src/WilsonFermion/WilsonFermion.jl
@@ -560,7 +560,7 @@ function Wx!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:AbstractGaugefiel
     clear_fermion!(temp)
     set_wing_fermion!(x, boundarycondition)
     for ν = 1:Dim
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         #println(xplus)
 
 
@@ -580,7 +580,7 @@ function Wx!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:AbstractGaugefiel
         ##    error("NaN detected in array temp1! 2")
         #end
 
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
 
 
@@ -651,19 +651,20 @@ function D4x!(xout::T1, U::Array{G,1}, x::T2, A, Dim) where {T1,T2,G<:AbstractGa
     temp2, it_temp2 = get_temp(A._temporary_fermi)#[2] #temps[2]
 
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(xout)
-    set_wing_fermion!(x)
+    set_wing_fermion!(x, boundarycondition)
 
 
     for ν = 1:Dim
 
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         mul!(temp1, U[ν], xplus)
         #... Dirac multiplication
         mul!(temp1, A.rminusγ[:, :, ν], temp1)
 
         #
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
         mul!(temp2, Uminus', xminus)
 
@@ -671,7 +672,7 @@ function D4x!(xout::T1, U::Array{G,1}, x::T2, A, Dim) where {T1,T2,G<:AbstractGa
         add_fermion!(xout, 0.5, temp1, 0.5, temp2)
 
     end
-    set_wing_fermion!(xout)
+    set_wing_fermion!(xout, boundarycondition)
 
     unused!(A._temporary_fermi, it_temp)
     unused!(A._temporary_fermi, it_temp1)
@@ -694,18 +695,19 @@ function D4dagx!(
     temp2, it_temp2 = get_temp(A._temporary_fermi)#[2] #temps[2]
 
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(xout)
-    set_wing_fermion!(x)
+    set_wing_fermion!(x, boundarycondition)
 
 
     for ν = 1:Dim
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         mul!(temp1, U[ν], xplus)
         #... Dirac multiplication
         mul!(temp1, A.rplusγ[:, :, ν], temp1)
 
         #
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
         mul!(temp2, Uminus', xminus)
 
@@ -713,7 +715,7 @@ function D4dagx!(
         add_fermion!(xout, 0.5, temp1, 0.5, temp2)
 
     end
-    set_wing_fermion!(xout)
+    set_wing_fermion!(xout, boundarycondition)
 
     unused!(A._temporary_fermi, it_temp)
     unused!(A._temporary_fermi, it_temp1)
@@ -731,18 +733,19 @@ function Dx!(xout::T1, U::Array{G,1}, x::T2, A::TA, Dim) where {T1,T2,G<:Abstrac
 
 
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(temp)
     #clear!(temp1)
     #clear!(temp2)
-    set_wing_fermion!(x)
+    set_wing_fermion!(x, boundarycondition)
     for ν = 1:Dim
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         mul!(temp1, U[ν], xplus)
         #... Dirac multiplication
         mul!(temp1, A.rminusγ[:, :, ν], temp1)
 
         #
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
         mul!(temp2, Uminus', xminus)
 
@@ -773,18 +776,19 @@ function Ddagx!(xout::T1, U::Array{G,1}, x::T2, A, Dim) where {T1,T2,G<:Abstract
     temp2, it_temp2 = get_temp(A._temporary_fermi)#[2] #temps[2]
 
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(temp)
     #clear!(temp1)
     #clear!(temp2)
-    set_wing_fermion!(x)
+    set_wing_fermion!(x, boundarycondition)
     for ν = 1:Dim
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         mul!(temp1, U[ν], xplus)
         #... Dirac multiplication
         mul!(temp1, A.rplusγ[:, :, ν], temp1)
 
         #
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
         mul!(temp2, Uminus', xminus)
 
@@ -819,11 +823,12 @@ function Tx!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:AbstractGaugefiel
     #temp1 = temps[1]
     #temp2 = temps[2]
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(temp)
-    #set_wing_fermion!(x)
+    set_wing_fermion!(x, boundarycondition)
     for ν = 1:Dim
 
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         #println(xplus)
 
 
@@ -838,7 +843,7 @@ function Tx!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:AbstractGaugefiel
 
 
 
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
 
 
@@ -884,10 +889,11 @@ function Wdagx_noclover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstr
     temp1, it_temp1 = get_temp(A._temporary_fermi)#i[1] #temps[1]
     temp2, it_temp2 = get_temp(A._temporary_fermi)#[2] #temps[2]
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(temp)
-    #set_wing_fermion!(x)
+    set_wing_fermion!(x, boundarycondition)
     for ν = 1:Dim
-        xplus = shift_fermion(x, ν)
+        xplus = shift_fermion(x, ν; boundarycondition)
         mul!(temp1, U[ν], xplus)
 
 
@@ -903,7 +909,7 @@ function Wdagx_noclover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstr
 
 
         #
-        xminus = shift_fermion(x, -ν)
+        xminus = shift_fermion(x, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
 
         mul!(temp2, Uminus', xminus)
@@ -920,7 +926,7 @@ function Wdagx_noclover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstr
 
     clear_fermion!(xout)
     add_fermion!(xout, 1, x, -1, temp)
-    set_wing_fermion!(xout, A.boundarycondition)
+    set_wing_fermion!(xout, boundarycondition)
 
     unused!(A._temporary_fermi, it_temp)
     unused!(A._temporary_fermi, it_temp1)
@@ -942,15 +948,16 @@ function Wdagx_clover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstrac
 
 
 
+    boundarycondition = get_boundarycondition(A)
     clear_fermion!(temp)
-    set_wing_fermion!(x, A.boundarycondition)
+    set_wing_fermion!(x, boundarycondition)
     x5 = A._temporary_fermi[5]
     mul_γ5x!(x5, x)
     #set_wing_fermion!(x5)
-    set_wing_fermion!(x5, A.boundarycondition)
+    set_wing_fermion!(x5, boundarycondition)
 
     for ν = 1:Dim
-        xplus = shift_fermion(x5, ν)
+        xplus = shift_fermion(x5, ν; boundarycondition)
         mul!(temp1, U[ν], xplus)
 
         #fermion_shift!(temp1,U,ν,x)
@@ -962,7 +969,7 @@ function Wdagx_clover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstrac
 
 
         #
-        xminus = shift_fermion(x5, -ν)
+        xminus = shift_fermion(x5, -ν; boundarycondition)
         Uminus = shift_U(U[ν], -ν)
 
         mul!(temp2, Uminus', xminus)
@@ -980,7 +987,7 @@ function Wdagx_clover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstrac
 
     clear_fermion!(temp1)
     add_fermion!(temp1, 1, x5, -1, temp)
-    set_wing_fermion!(temp1, A.boundarycondition)
+    set_wing_fermion!(temp1, boundarycondition)
     cloverterm_σμν!(temp1, A.cloverterm, x5, temp, temp2)
     #println("before ",dot(temp1,temp1))
     #println("x5 ",dot(x5,x5))
@@ -998,7 +1005,7 @@ function Wdagx_clover!(xout::T, U::Array{G,1}, x::T, A, Dim) where {T,G<:Abstrac
     #add_fermion!(xout, 1, x, -1, temp)
     #mul_γ5x!(xout,temp)
     mul_γ5x!(xout, temp1)
-    set_wing_fermion!(xout, A.boundarycondition)
+    set_wing_fermion!(xout, boundarycondition)
 
 
     unused!(A._temporary_fermi, it_temp)

--- a/src/WilsonFermion/WilsonFermion_4D.jl
+++ b/src/WilsonFermion/WilsonFermion_4D.jl
@@ -110,7 +110,7 @@ function Toex!(
     x::T,
     A,
     iseven;
-    boundarycondition=boundarycondition_default
+    boundarycondition=get_boundarycondition(A)
 ) where {T<:WilsonFermion_4D,G<:AbstractGaugefields} #T_oe xe
     temps = A._temporary_fermi
     temp1, it_temp1 = get_temp(temps)
@@ -149,7 +149,7 @@ function Tdagoex!(
     x::T,
     A,
     iseven;
-    boundarycondition=boundarycondition_default
+    boundarycondition=get_boundarycondition(A)
 ) where {T<:WilsonFermion_4D,G<:AbstractGaugefields} #T_oe xe
     temps = A._temporary_fermi
     temp1, it_temp1 = get_temp(temps)

--- a/src/WilsonFermion/WilsonFermion_4D_nowing_mpi.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_nowing_mpi.jl
@@ -305,7 +305,11 @@ function getvalue(
     @inbounds return F.parent.fshifted[i1, i2, i3, i4, i5, i6]
 end
 
-function shift_fermion(F::WilsonFermion_4D_nowing_mpi{NC}, ν::T) where {T<:Integer,NC}
+function shift_fermion(
+    F::WilsonFermion_4D_nowing_mpi{NC},
+    ν::T;
+    boundarycondition=boundarycondition_default,
+) where {T<:Integer,NC}
     if ν == 1
         shift = (1, 0, 0, 0)
     elseif ν == 2
@@ -324,7 +328,7 @@ function shift_fermion(F::WilsonFermion_4D_nowing_mpi{NC}, ν::T) where {T<:Inte
         shift = (0, 0, 0, -1)
     end
 
-    return Shifted_fermionfields_4D_nowing_mpi(F, shift)
+    return Shifted_fermionfields_4D_nowing_mpi(F, shift; boundarycondition)
 end
 
 
@@ -2444,5 +2448,4 @@ function mul_1plusγ4x!(y::WilsonFermion_4D_nowing_mpi{NC}, x) where {NC}#(1+gam
         end
     end
 end
-
 

--- a/src/WilsonFermion/WilsonFermion_4D_wing.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_wing.jl
@@ -323,7 +323,7 @@ function set_wing_fermion!(
         for it = 1:NT
             for iy = 1:NY
                 for ix = 1:NX
-                    iz = NX
+                    iz = NZ
                     evenodd = ifelse((ix + iy + iz + it) % 2 == 0, true, false)
                     if evenodd == iseven
                         @simd for k = 1:NC
@@ -1328,4 +1328,3 @@ function cloverterm!(vec::WilsonFermion_4D_wing{NC}, cloverterm, x::WilsonFermio
     #println("vec = ",vec*vec)
 
 end
-

--- a/src/WilsonFermion/WilsonFermion_4D_wing_Adjoint.jl
+++ b/src/WilsonFermion/WilsonFermion_4D_wing_Adjoint.jl
@@ -317,7 +317,7 @@ function set_wing_fermion!(
         for it = 1:NT
             for iy = 1:NY
                 for ix = 1:NX
-                    iz = NX
+                    iz = NZ
                     evenodd = ifelse((ix + iy + iz + it) % 2 == 0, true, false)
                     if evenodd == iseven
                         @simd for k = 1:NumofBasis

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,10 @@ using LinearAlgebra
         include("solver_diagnostics.jl")
     end
 
+    @testset "Wilson boundary conditions" begin
+        include("wilson_boundary_conditions.jl")
+    end
+
     @testset "Wilson HMC" begin
         println("Wilson HMC")
         include("wilsonhmc.jl")

--- a/test/wilson_boundary_conditions.jl
+++ b/test/wilson_boundary_conditions.jl
@@ -1,0 +1,84 @@
+function temporal_slice(field, it)
+    return [
+        field[ic, ix, iy, iz, it, ialpha] for
+        ialpha = 1:field.NG, iz = 1:field.NZ, iy = 1:field.NY,
+        ix = 1:field.NX, ic = 1:field.NC
+    ]
+end
+
+@testset "non-wing Wilson temporal boundary condition" begin
+    NX, NY, NZ, NT = 2, 2, 2, 3
+    NC = 3
+    U = Initialize_Gaugefields(NC, 0, NX, NY, NZ, NT; condition="cold")
+    source = Initialize_pseudofermion_fields(U[1], "Wilson"; nowing=true)
+    clear_fermion!(source)
+    setindex_global!(source, 1, 1, 1, 1, 1, 1, 1)
+
+    base_parameters = Dict{String,Any}(
+        "Dirac_operator" => "Wilson",
+        "κ" => 0.1,
+        "r" => 1.0,
+        "faster version" => false,
+        "verbose_level" => 0,
+    )
+    periodic_parameters = copy(base_parameters)
+    periodic_parameters["boundarycondition"] = [1, 1, 1, 1]
+    antiperiodic_parameters = copy(base_parameters)
+    antiperiodic_parameters["boundarycondition"] = [1, 1, 1, -1]
+
+    periodic_operator = Dirac_operator(U, source, periodic_parameters)
+    antiperiodic_operator = Dirac_operator(U, source, antiperiodic_parameters)
+
+    periodic_result = similar(source)
+    antiperiodic_result = similar(source)
+    clear_fermion!(periodic_result)
+    clear_fermion!(antiperiodic_result)
+    mul!(periodic_result, periodic_operator, source)
+    mul!(antiperiodic_result, antiperiodic_operator, source)
+
+    periodic_boundary_slice = temporal_slice(periodic_result, NT)
+    antiperiodic_boundary_slice = temporal_slice(antiperiodic_result, NT)
+    @test norm(periodic_boundary_slice) > 0
+    @test periodic_boundary_slice ≈ -antiperiodic_boundary_slice
+
+    periodic_adjoint_result = similar(source)
+    antiperiodic_adjoint_result = similar(source)
+    clear_fermion!(periodic_adjoint_result)
+    clear_fermion!(antiperiodic_adjoint_result)
+    mul!(periodic_adjoint_result, periodic_operator', source)
+    mul!(antiperiodic_adjoint_result, antiperiodic_operator', source)
+
+    periodic_adjoint_boundary_slice = temporal_slice(periodic_adjoint_result, NT)
+    antiperiodic_adjoint_boundary_slice =
+        temporal_slice(antiperiodic_adjoint_result, NT)
+    @test norm(periodic_adjoint_boundary_slice) > 0
+    @test periodic_adjoint_boundary_slice ≈
+          -antiperiodic_adjoint_boundary_slice
+end
+
+function check_lower_z_evenodd_halo!(field, target_is_even)
+    clear_fermion!(field)
+    for ialpha = 1:field.NG, it = 1:field.NT, iy = 1:field.NY,
+        ix = 1:field.NX
+        field[1, ix, iy, field.NZ, it, ialpha] = 1
+    end
+
+    set_wing_fermion!(field, [1, 1, 1, 1], target_is_even)
+    for ialpha = 1:field.NG, it = 1:field.NT, iy = 1:field.NY,
+        ix = 1:field.NX
+        source_is_even = iseven((ix + iy + field.NZ + it) % 2)
+        expected = source_is_even == target_is_even ? 1 : 0
+        @test field[1, ix, iy, 0, it, ialpha] == expected
+    end
+end
+
+@testset "non-cubic even-odd lower-z halo parity" begin
+    NX, NY, NZ, NT = 2, 2, 3, 2
+    fundamental = WilsonFermion_4D_wing{3}(NX, NY, NZ, NT)
+    check_lower_z_evenodd_halo!(fundamental, true)
+    check_lower_z_evenodd_halo!(fundamental, false)
+
+    adjoint = initialize_Adjoint_fermion(fundamental)
+    check_lower_z_evenodd_halo!(adjoint, true)
+    check_lower_z_evenodd_halo!(adjoint, false)
+end

--- a/test/wilson_boundary_conditions.jl
+++ b/test/wilson_boundary_conditions.jl
@@ -74,7 +74,8 @@ end
 
 @testset "non-cubic even-odd lower-z halo parity" begin
     NX, NY, NZ, NT = 2, 2, 3, 2
-    fundamental = WilsonFermion_4D_wing{3}(NX, NY, NZ, NT)
+    fundamental =
+        Initialize_WilsonFermion(3, NX, NY, NZ, NT; nowing=false)
     check_lower_z_evenodd_halo!(fundamental, true)
     check_lower_z_evenodd_halo!(fundamental, false)
 


### PR DESCRIPTION
## What

- pass each Wilson operator's configured boundary condition into non-wing shifts
- preserve the existing halo-based behavior for wing fields and compatibility for 2D fields
- propagate boundary conditions through forward, adjoint, hopping, and even-odd paths
- use `NZ`, not `NX`, to select lower-z halo parity in fundamental and adjoint wing fields
- add periodic-vs-antiperiodic and non-cubic even-odd halo regression tests

## Why / root cause

The non-wing Wilson path called `shift_fermion` without the operator boundary condition, so an explicitly periodic temporal boundary silently used the default antiperiodic phase. Separately, the lower-z even-odd halo code used `iz = NX`; this selects the wrong parity whenever `NX` and `NZ` differ in parity.

Both defects are configuration-sensitive: the default antiperiodic temporal boundary masks the first, while cubic lattices with matching x/z parity mask the second. The added regressions exercise the previously uncovered configurations directly.

## Impact

Explicit boundary conditions now agree across wing and non-wing Wilson fields, and even-odd halos work on non-cubic lattices. Existing configurations that already use the defaults or matching x/z parity retain their prior numerical behavior.

## Stack

Depends on #83 and the preceding solver-diagnostics stack.

## Checks

On `ubuntuamd` (CPU only, Julia/OpenBLAS threads = 1, GPU disabled):

- non-wing temporal boundary regression: 4/4 passed
- non-cubic even-odd halo regression: 128/128 passed
- full LatticeDiracOperators package tests: 195/195 passed
- exact tested head: `5f01b3b1f09390888d87e060110df2c5928b1189`
- Julia: 1.12.3
- documentation dependency install and GitHub Actions build: passed
- log root: `/home/akio/runs/juliaqcd_ci_fix_validation_20260806T0030JST_r4`

Earlier validation at pre-CI-fix head `660d5f1` produced the same 132/132 and 195/195 results. The rebase changes the tree only by removing the non-portable root Manifest.